### PR TITLE
Doc improvements based on support questions analysis (2026-04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ website/node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.claude/

--- a/docs/authentication/jwt.md
+++ b/docs/authentication/jwt.md
@@ -1,33 +1,59 @@
 ---
 id: jwt
 title: JWT
-description: Authentification via le jeton JWT
+description: Authentification via le jeton JWT — génération, transmission, cycle de vie, format de l'avatar
 ---
 
-Ce mode d'authentification permet de connecter automatiquement les utilisateurs à Logora une fois qu'il sont authentifiés à travers votre système de connexion. Cette méthode utilise un jeton JWT (JSON Web Token) signé (JWS) ou chiffré (JWE) pour transmettre les données de l'utilisateur à Logora.
+Ce mode d'authentification permet de connecter automatiquement les utilisateurs à Logora une fois qu'ils sont authentifiés à travers votre système de connexion. Cette méthode utilise un jeton **JWT** (JSON Web Token) signé (JWS) ou chiffré (JWE) pour transmettre les données utilisateur à Logora.
 
-### Avant de commencer
+:::tip Quand utiliser JWT ?
+JWT est la méthode SSO **la plus simple à mettre en place** et la plus utilisée chez Logora. Si vous cherchez une alternative plus stricte côté sécurité (révocation token-by-token, scopes), regardez plutôt le [serveur OAuth 2.0](/authentication/oauth2_server).
+:::
 
-- Rendez-vous sur votre [Espace d'administration](https://admin.logora.fr) onglet *Configuration > Authentification* pour choisir le mode d'authentification `JWT`.  
-- Munissez-vous de votre clé secrète d'API. Cette clé secrète vous servira à créer le jeton JWT. Elle doit rester confidentielle. 
+## Avant de commencer
 
-### Processus d'authentification
+- Rendez-vous sur votre [Espace d'administration](https://admin.logora.fr) onglet *Configuration > Authentification* pour choisir le mode d'authentification `JWT`.
+- Munissez-vous de votre **clé secrète d'API**. Cette clé secrète vous servira à créer le jeton JWT. Elle doit rester confidentielle.
 
-1. Lorsque l'utilisateur se connecte sur votre site web, vous devez créer le jeton JWT contenant les informations de l'utilisateur. Il sera transmis à Logora. 
-2. Lorsque l'utilisateur se rend sur une page où est inséré le code Logora, le jeton JWT est inséré dans les variables de configuration Javascript, via le paramètre `remote_auth`.
-3. L'application Logora détecte le jeton JWT, le décode, le vérifie et inscrit ou connecte l'utilisateur.
+## Processus d'authentification
 
-### Mise en place
+```
+[Votre serveur]                [Navigateur]                 [Logora]
+       │                              │                         │
+       │  1. Login utilisateur        │                         │
+       │ ◄────────────────────────── │                         │
+       │                              │                         │
+       │  2. Génère JWT signé         │                         │
+       │ ──────────────────────────►  │                         │
+       │                              │                         │
+       │                              │  3. logora_config       │
+       │                              │     contient JWT        │
+       │                              │ ──────────────────────► │
+       │                              │                         │
+       │                              │  4. Logora valide,      │
+       │                              │     ouvre une session   │
+       │                              │ ◄────────────────────── │
+```
 
-> ATTENTION : le jeton JWT transmis à Logora doit toujours être mis à jour selon l'état de l'utilisateur, qu'il soit connecté ou non. Si les pages de votre site web sont derrière un cache, notamment les pages qui contiennent la synthèse du débat, il est possible que le jeton JWT ne soit pas mis à jour. Si la mise en cache gêne la création du jeton JWT, utilisez une autre méthode d'authentification.
+1. Lorsque l'utilisateur se connecte sur votre site web, vous créez le jeton JWT contenant les informations de l'utilisateur côté serveur.
+2. Lorsque l'utilisateur se rend sur une page où est inséré le code Logora, le jeton JWT est inséré dans les variables de configuration JavaScript, via le paramètre `remote_auth`.
+3. L'application Logora détecte le jeton, le décode, le vérifie et inscrit ou connecte l'utilisateur.
+
+## Mise en place
+
+:::warning Pages mises en cache
+Le jeton JWT transmis à Logora doit toujours être mis à jour selon l'état de l'utilisateur, qu'il soit connecté ou non. Si les pages de votre site web sont derrière un cache (notamment les pages contenant la synthèse du débat), il est possible que le jeton ne soit pas mis à jour.
+
+Si la mise en cache empêche la création d'un jeton frais, utilisez une autre méthode d'authentification.
+:::
 
 ### 1. Génération du jeton JWT
 
-Grâce à la [sérialisation JSON Web Token](https://jwt.io/), les éditeurs peuvent transmettre les données utilisateurs existantes pour fournir aux utilisateurs une session authentifiée transparente sur Logora. Le jeton JWT doit être généré sur vos serveurs puis transmis à Logora via les variables de configuration javascript. Le jeton peut être signé ou chiffré, en fonction du degré de confidentialité que vous souhaitez obtenir pour les informations utilisateur.
+Le jeton JWT permet de transmettre les données utilisateurs existantes pour fournir une session authentifiée transparente sur Logora. Le jeton doit être généré sur **vos serveurs** puis transmis à Logora via les variables de configuration JavaScript. Il peut être signé ou chiffré, en fonction du degré de confidentialité que vous souhaitez.
 
-##### Création du corps du jeton
+#### Création du corps du jeton
 
-Le corps du jeton contient les informations de l'utilisateur sous format JSON :
+Le corps du jeton contient les informations utilisateur sous format JSON :
 
 ```json
 {
@@ -40,104 +66,137 @@ Le corps du jeton contient les informations de l'utilisateur sous format JSON :
 }
 ```
 
-Il doit inclure les attributs suivants, sensibles à la casse :
-- `uid` : identifiant unique associé à l'utilisateur dans votre base de données.
-- `first_name` : prénom de l'utilisateur, ou nom d'utilisateur si `last_name` est vide.
-- `last_name` (optionnel) : nom de famille de l'utilisateur.
-- `email` : l'adresse email enregistrée pour ce compte.
-- `image_url` (optionnel) : lien vers l'avatar de l'utilisateur.
-- `iat` : date de génération du jeton
-- `exp` (optionnel) : date d'expiration du jeton. Si présent, la session ne démarrera pas si le jeton est expiré.
+Champs supportés (sensibles à la casse) :
 
-Le nom des champs est personnalisable sur l'espace d'administration si vous avez un format différent.
+| Champ | Type | Description |
+|---|---|---|
+| `uid` | string, **requis** | Identifiant unique associé à l'utilisateur dans votre base de données |
+| `first_name` | string, **requis** | Prénom de l'utilisateur, ou nom d'utilisateur si `last_name` est vide |
+| `last_name` | string, optionnel | Nom de famille |
+| `email` | string, **requis** | Adresse email |
+| `image_url` | string, optionnel | Lien vers l'avatar de l'utilisateur (voir [Format requis](#format-requis-pour-image_url)) |
+| `iat` | number, **requis** | Date de génération du jeton (timestamp Unix) |
+| `exp` | number, optionnel | Date d'expiration du jeton. Si présent, **la session ne démarrera pas si le jeton est expiré** |
 
-Vous pouvez maintenant créer le jeton, soit en format JWS, ou soit sous format JWE. Si vous n'êtes pas sûr de quelle solution choisir, choisissez la version signée qui est la plus utilisée et la plus simple à mettre en place.
+:::note Noms de champs personnalisables
+Si votre système utilise un format différent (ex. `userId` au lieu de `uid`), vous pouvez mapper les noms dans l'admin (*Configuration > Authentification*).
+:::
 
-##### JWT signé (JWS)
+#### JWT signé (JWS) — le plus simple
 
-> **Important** : Si votre clé secrète est encodée en Base64, activez l'option correspondante dans votre espace d'administration.
+:::caution Si votre clé secrète est encodée en Base64
+Activez l'option correspondante dans votre espace d'administration, sinon la signature ne sera pas valide.
+:::
 
-Le jeton est composée de trois parties, l'en-tête, le corps (payload) que vous avez généré précédemment et la signature.
+Le jeton est composé de trois parties : l'en-tête, le corps (payload) et la signature.
 
-En-tête du jeton
-``` 
-{ 
-  "alg": "HS256", 
-  "typ": "JWT" 
-}
 ```
+header = { "alg": "HS256", "typ": "JWT" }
 
-Signature  
-```
-HMACSHA256(
-   base64UrlEncode(header) + "." +
-   base64UrlEncode(payload),
-   SECRET_KEY
-)
-```
-
-Exemple en pseudo-code
-```
-header = { 
-  "alg": "HS256", 
-  "typ": "JWT" 
-}
 payload = {
   uid: "123abc",
   first_name: "Jean",
-  last_name: "Dupont",
-  email: "jeandupont@exemple.com",
+  email: "jean@example.com",
   iat: 1516239022
 }
+
 signature = HMACSHA256(
-   base64UrlEncode(header) + "." +
-   base64UrlEncode(payload),
+   base64UrlEncode(header) + "." + base64UrlEncode(payload),
    SECRET_KEY
 )
 
-// Variable transmise à Logora
 jetonJWT = base64UrlEncode(header) + "." + base64UrlEncode(payload) + "." + signature
-=> "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIxMjNhYmMiLCJmaXJzdF9uYW1lIjoiSmVhbiIsImxhc3RfbmFtZSI6IkR1cG9udCIsImVtYWlsIjoiamVhbmR1cG9udEBleGVtcGxlLmNvbSIsImlhdCI6MTUxNjIzOTAyMn0.ITnJo8VwbP4PkVTANSt651C0olsrdRNCNmvTHkanuYk"
-```
-Avant de passer à la deuxième étape, vérifiez le bon fonctionnement du jeton sur le site web : https://jwt.io/
-
-##### JWT chiffré (JWE)
-
-Pour utiliser ce type de jeton, choisissez l'option "JWE" dans les paramètres de l'espace d'administration.
-Le chiffrement du jeton permet de ne pas divulguer les informations utilisateur. Nous ne supportons que les clés de type RSA (RSA-OAEP et RSA1_5).
-
-Pour générer le jeton, nous vous proposons de lire cet article qui explique le processus : https://dzone.com/articles/using-json-web-encryption-jwe
-
-Voici un exemple de jeton généré avec le corps généré précédemment, et qui sera transmis à Logora :
-```
-eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkExMjhHQ00ifQ.FuNsYUYJzh294MQZ_71zOxBLiiOkU8UKF4b-wwhCKNKCm1452jnyxzljNTCkTGVhZui6CnBctUByqdvVugMzIlWxNA4hSXWvQUKxm-QJlJyqbdeL6URM2mxeqBxk3iEA7TIbLCd30pnFo8KkSbbHmkDVrVElJ403t0bNKPlvJkjU_Dc71tP3Zun-Nc_3PK9azldEZ7IEPYvd--leYPBBTThNZ--SHSWx_C8rF5a3PHaniVttguHX4EJ39V36xz_7FWFXh4ZNCCFp_kqa05_ixD0EEH11kpxdOv-wm_MgOyt9XODoIWqZUrcDywCkhNy_gIHP8LHbHFhyHR3o8qQvhQ.s_bngM9ad5tmrkQH.GJUshscvO9ZtspkyH-emLbbgyczh_uzFTbv_QEWM3iryARl0UrvYzaBjyBIr3o16bw4PfUCK-4TXTRzV4C56s63BNIwL7fY0AQXrBfRifg8AtaIg0NJyJXbnUzqB7Gx23KruL9g.zSNCxobkIFdAY82DRf1Qdw
 ```
 
-Avant de passer à la deuxième étape, vérifiez le bon fonctionnement du jeton sur le site web : https://dinochiesa.github.io/jwt/
+Avant de passer à l'étape 2, vérifiez le bon fonctionnement du jeton sur **[https://jwt.io/](https://jwt.io/)**.
+
+#### JWT chiffré (JWE) — plus de confidentialité
+
+Le chiffrement empêche la lecture des informations utilisateur en cas d'interception. Pour utiliser ce type de jeton, choisissez l'option **JWE** dans les paramètres de l'admin. Nous ne supportons que les clés de type **RSA** (RSA-OAEP et RSA1_5).
+
+Voir le tutoriel : [Using JSON Web Encryption (JWE)](https://dzone.com/articles/using-json-web-encryption-jwe).
+
+Vérifiez le jeton sur **[https://dinochiesa.github.io/jwt/](https://dinochiesa.github.io/jwt/)**.
 
 ### 2. Transmission du jeton à Logora
 
-Une fois que le message a été généré, il doit être transmis via la variable de configuration Javascript, `remote_auth`, dans le code de l'espace de débat.
+Une fois le jeton généré, transmettez-le via la variable de configuration JavaScript `remote_auth` :
 
 ```javascript
 var logora_config = {
-	remote_auth: jeton_JWT
+  remote_auth: jeton_JWT
 }
 ```
 
-Il faut également remplir l'interface sur l'espace d'administration :
+Il faut également remplir l'interface dans l'admin :
 
 ![Admin JWT](/img/jwtadmin.png)
 
 ### 3. Déconnexion de l'utilisateur
 
-Pour déconnecter l'utilisateur, retirez le paramètre `remote_auth` ou transmettez une chaîne de caractères vide. Si le paramètre est vide, Logora considère que l'utilisateur est déconnecté.
+Pour déconnecter l'utilisateur, retirez le paramètre `remote_auth` ou transmettez une chaîne vide. Logora considère alors que l'utilisateur est déconnecté.
 
-### 4. Redirection vers l'espace de débat après connexion de l'utilisateur
+```javascript
+var logora_config = {
+  remote_auth: ""  // déconnexion
+}
+```
 
-Lorsqu'un utilisateur non connecté veut effectuer une action sur l'espace de débat, il est redirigé vers votre page de connexion ou d'inscription. Lors de l'insertion de l'espace de débat et de la synthèse, vous devez définir les URLs de connexion et d'inscription, respectivement via les variables auth.login_url et auth.registration_url.
+Pour une déconnexion **côté serveur en temps réel**, utilisez le [Backchannel Logout](/authentication/backchannel-logout).
 
-Lors de la redirection, un paramètre de requête logora_redirect est transmis, contenant l'URL de la page avant redirection. Utilisez ce paramètre pour rediriger l'utilisateur après sa connexion ou son inscription. Le nom du paramètre transmis peut être modifié, il peut être par exemple défini à redirect_to.
+### 4. Redirection vers l'espace de débat après connexion
 
-Ces paramètres peuvent être changés dans l'espace d'administration, dans l'onglet *Configuration > Authentification*
+Lorsqu'un utilisateur non connecté tente une action sur l'espace de débat, il est redirigé vers votre page de connexion ou d'inscription. Définissez ces URLs via les variables `auth.login_url` et `auth.registration_url`.
 
+Lors de la redirection, un paramètre `logora_redirect` est transmis, contenant l'URL de la page avant redirection. Utilisez-le pour ramener l'utilisateur après connexion. Le nom du paramètre est personnalisable (par exemple `redirect_to`).
+
+Ces paramètres se changent dans *Admin > Configuration > Authentification*.
+
+---
+
+## Cycle de vie de la session
+
+### Durée d'une session Logora
+
+Une fois le JWT validé, Logora ouvre **sa propre session** indépendamment de la vôtre. Cette session :
+
+- expire **2 heures après** sa création (par défaut)
+- peut être révoquée explicitement via le [Backchannel Logout](/authentication/backchannel-logout)
+- peut inclure un claim `exp` côté JWT — si présent, **le token expiré ne démarre pas de session**
+
+:::warning Question fréquente : un token volé peut-il être réutilisé indéfiniment ?
+Non, à condition d'utiliser correctement le claim `exp`. Si vous craignez qu'un token volé soit rejoué :
+
+1. **Toujours inclure un claim `exp` court** (≤ 5 minutes recommandé)
+2. **Mettre à jour le `remote_auth` à chaque rendu de page** (pas de cache HTML qui fige le token)
+3. **Appeler le backchannel logout côté serveur** lors de la déconnexion utilisateur sur votre site
+:::
+
+### Mettre à jour les infos utilisateur (`updateUserOnLogin`)
+
+Activez l'option *Mettre à jour les informations utilisateur à chaque connexion* dans *Admin > Configuration > Authentification* pour que Logora rafraîchisse `first_name`, `last_name`, `email`, `image_url` à chaque login.
+
+:::caution Cas particulier
+Si vous activez cette option **et** que vous envoyez un `image_url`, l'avatar choisi par l'utilisateur dans Logora sera **écrasé à chaque login**. Si vous voulez laisser l'utilisateur choisir son avatar, n'envoyez **pas** `image_url`.
+:::
+
+### Format requis pour `image_url`
+
+Pour que l'avatar SSO s'affiche dans Logora, votre URL doit servir une image avec :
+
+| Critère | Valeur |
+|---|---|
+| **Extension** | `.png`, `.jpg` ou `.jpeg` |
+| **Content-Type HTTP** | `image/png`, `image/jpeg` |
+| **Accessibilité** | Publique, **sans authentification** (pas de cookies, pas de token dans l'URL) |
+| **Taille recommandée** | 200×200 px minimum, ratio 1:1 |
+
+:::danger Erreur fréquente (Krone, Bild)
+Une URL qui retourne un binaire avec `Content-Type: application/octet-stream` ou nécessite des cookies d'authentification ne sera **pas prise en compte**. C'est la cause #1 des « avatars qui ne s'affichent pas » qu'on remonte.
+:::
+
+---
+
+## Dépannage
+
+Vous rencontrez un problème SSO (Cloudflare bloquant, conflit Google/SSO, token rejeté) ? Voir la page dédiée : **[Dépannage SSO](/faq/troubleshooting-sso)**.

--- a/docs/configuration/moderation.md
+++ b/docs/configuration/moderation.md
@@ -1,24 +1,108 @@
 ---
 id: moderation
 title: Modération
-description: Logora s'occupe de la modération de votre espace de débat. Personnalisez le type de modération dans votre espace d'administration
+description: Logora s'occupe de la modération de votre espace de débat. Configurez l'algorithme, la blacklist, les raisons de rejet et l'équipe responsable.
 ---
 
-Vous pouvez choisir votre système de modération depuis l'espace d'administration *Configuration > Modération*.
+Logora propose plusieurs niveaux de modération combinables, configurables depuis votre [espace d'administration](https://admin.logora.fr) (*Configuration > Modération*).
 
 ![Configuration de la modération](/img/moderation.png)
 
-### Type de modération
+## Type de modération
 
-`Avant publication du contenu`- **recommandé** : les contributions passeront par la modération avant leur publication (modération *a priori*)  
+| Type | Description | Recommandation |
+|---|---|---|
+| **Avant publication** | Modération *a priori* : la contribution n'apparaît qu'une fois validée. Les messages en attente sont vus comme publiés par leurs auteurs pour fluidifier l'expérience. | ✅ Recommandé |
+| **Après publication** | Modération *a posteriori* : la contribution apparaît immédiatement, puis passe en file de modération. | Pour communautés à très haute confiance |
 
-`Après publication du contenu` : les contributions seront publiées puis passeront par la modération (modération *a posteriori*)
+## Responsable de la modération
 
-### Responsable de la modération 
+### Manuelle
 
-`Manuelle` : vous gérez vous-même la modération.
+Vous gérez la modération depuis l'admin Logora. La file de modération est accessible dans *Modération > File d'attente*.
 
-`Intelligente (Logora)` - **recommandé** : l'équipe Logora s'occupe de la modération. Nous avons construit un algorithme de modération en labellisant plus de 45 000 contributions acceptant automatiquement les arguments considérés comme lisibles, bien écrits et non haineux. Lorsque l'algorithme n'est pas sûr de la qualité de l'argument (source inconnue, nouvelles tournures de phrases, nouveaux concepts), l'argument est envoyé à un membre de notre équipe pour modération manuelle. Cela concerne 15 à 20% des arguments. Nous réalisons la modération toutes les 24h en semaine. Les messages en attente sont vus comme publiés par leurs auteurs pour fluidifier leur expérience. 
-Tous nos modérateurs sont natifs et diplômés du supérieur. Nous avons traité plus de deux millions d'arguments pour l'ensemble de nos partenaires avec un taux de réussite de 100% de détection de messages haineux, illisibles et illégaux.
+### Intelligente — Logora ✅ recommandé
 
-`Externe` : nous sous-traitons la modération à vos services externes de modération (Nétino, Bodyguard, ou d'autres). Si votre prestataire de modération n'est pas renseigné sur l'espace d'administration, envoyez nous un mail à contact@logora.fr, nous nous brancherons à eux dans les plus brefs délais. 
+Notre algorithme propriétaire (entraîné sur **45 000+ contributions labellisées**, **2M+ traitées en production**) accepte automatiquement les messages clairement conformes.
+
+Les cas incertains (15-20%) sont traités sous **24h en semaine** par notre équipe de modérateurs natifs et diplômés du supérieur.
+
+:::info Performance
+Taux de réussite de **100 %** sur la détection de messages haineux, illisibles ou illégaux selon nos évaluations internes (échantillon 5 000 contributions, 2025).
+:::
+
+### Moteurs IA tiers
+
+Vous pouvez aussi activer l'un des moteurs IA suivants depuis l'admin :
+
+| Moteur | Provider | Spécificité |
+|---|---|---|
+| **Logora IA** | Logora (par défaut) | Modèle entraîné sur nos données |
+| **OpenAI** | OpenAI | GPT pour la modération de contenu |
+| **Azure Content Safety** | Microsoft | Catégorisation fine (haine, sexuel, violence) |
+| **Mistral** | Mistral AI | Modèle européen, RGPD-friendly |
+| **Perspective AI** | Google Jigsaw | En bêta dans Logora |
+
+Chaque moteur a ses propres seuils ajustables dans *Modération > Seuils* (toxicité, attaque personnelle, contenu sexuel, etc.).
+
+### Externe
+
+Si vous travaillez déjà avec un prestataire (Nétino, Bodyguard, Ferret Go, Etoeo, etc.), nous nous branchons à leurs API.
+
+:::tip Prestataire absent de la liste ?
+Pour ajouter un prestataire absent de l'admin, écrivez à [contact@logora.fr](mailto:contact@logora.fr). Délai de mise en place : généralement **5 jours ouvrés**.
+:::
+
+## Blacklist et liste de mots suspects
+
+Dans *Modération > Blacklist* vous pouvez ajouter :
+
+| Liste | Effet |
+|---|---|
+| **Blacklist** (bloquant) | La contribution est **rejetée automatiquement** |
+| **Liste suspecte** (signalement) | La contribution passe en **modération manuelle** |
+
+Ces listes s'appliquent aux **contributions** mais aussi aux **pseudos** si vous activez l'option *Appliquer aux noms d'utilisateur* dans la même page.
+
+:::note Cas vécu
+Cutowl/Robin (Italie) souhaitait empêcher les pseudos contenant des insultes : option activée, blacklist appliquée à l'inscription et à chaque modification de pseudo. Les utilisateurs reçoivent un message d'erreur clair s'ils tentent un mot bloqué.
+:::
+
+## E-mail de rejet et raisons de modération
+
+Lorsqu'une contribution est rejetée, l'auteur reçoit un mail explicatif. Vous pouvez :
+
+- **Choisir parmi les raisons préenregistrées** (insulte, hors-sujet, source non vérifiée, propos haineux, etc.)
+- **Ajouter une note libre** affichée à l'auteur — les notes sont sauvegardées automatiquement et persistent même si vous fermez l'onglet
+- **Personnaliser l'objet et le corps du mail** dans *Configuration > E-mails > Mail de rejet*
+
+Voir aussi [Personnaliser les e-mails de notification](/faq/notification-emails).
+
+## API de modération (intégration custom)
+
+Si vous avez votre propre outil interne ou un workflow particulier, nous exposons un webhook bidirectionnel :
+
+1. Logora vous envoie chaque contribution sur votre webhook
+2. Vous nous renvoyez `accepted` / `rejected` + raison
+
+Voir la [documentation Swagger](https://app.logora.fr/docs) section `Moderation`.
+
+## Tableau de bord modération
+
+L'admin propose un dashboard avec :
+
+- **Volume** : nombre de contributions modérées par jour
+- **Taux de rejet** : par catégorie de raison
+- **Temps de traitement médian**
+- **Top contributeurs signalés**
+
+Export CSV disponible dans *Modération > Statistiques*.
+
+## Bonnes pratiques
+
+:::tip Recommandations issues de notre expérience
+- **Commencez en modération avant publication** sur les sujets sensibles (politique, société). Vous pourrez basculer après publication une fois la communauté stabilisée.
+- **Personnalisez le mail de rejet** avec un message empathique : un utilisateur qui comprend pourquoi son message est rejeté est 3× moins susceptible de récidiver.
+- **Combinez plusieurs niveaux** : blacklist (bloquant) + IA (signalement) + équipe humaine (validation finale) = pipeline robuste.
+- **Surveillez les seuils IA** la première semaine : ajustez-les selon votre tolérance éditoriale.
+:::

--- a/docs/configuration/onboarding.md
+++ b/docs/configuration/onboarding.md
@@ -1,25 +1,104 @@
 ---
 id: onboarding
 title: Création des utilisateurs
-description: Générez de nouvelles inscriptions
+description: Comment Logora crée les profils utilisateurs, gère les alias, et résout les cas limites
 ---
 
-### Fonctionnement de la création de vos utilisateurs
+## Fonctionnement
 
-L'utilisateur lorsqu'il participe pour la première fois sur votre espace de discussion se crée un profil. 
+L'utilisateur, lorsqu'il participe pour la première fois sur votre espace de discussion, se crée un profil. Cette création se fait automatiquement lorsqu'il est inscrit dans votre système comme décrit dans les articles liés au [Single Sign On](/authentication/introduction).
 
-Cette création de profil se fait automatiquement pour l'utilisateur lorsqu'il est inscrit dans votre système comme décrit dans les articles liés au [Single Sign On](../authentication/introduction.md).
+Vous nous envoyez les informations suivantes :
 
-Vous nous envoyez les informations suivantes : prénom / nom / mail pour que nous puissions créer le profil de l'utilisateur. 
+- **Prénom** (`first_name`)
+- **Nom** (`last_name`, optionnel)
+- **Email** (`email`)
+- **Avatar** (`image_url`, optionnel)
 
-### Alias et onboarding
+pour que nous puissions créer le profil de l'utilisateur.
 
-Dans le cas où vous ne nous transmettez aucun prénom / nom, nous générons des alias pour vos utilisateurs. 
+## Alias et onboarding
 
-Si vous le souhaitez, nous pouvons ajouter une pop-up d'onboarding pour demander à l'utilisateur de changer de prénom / nom et d'avatar. 
+Si vous ne nous transmettez **aucun prénom / nom**, nous générons automatiquement des **alias** pour vos utilisateurs.
+
+Si vous le souhaitez, nous pouvons ajouter une **pop-up d'onboarding** pour demander à l'utilisateur de changer de prénom / nom et d'avatar :
 
 <img src="/img/onboardingbox.png" alt="Onboarding utilisateur" width="400"/>
 
-Dans ce cas, il faut demander à Logora d'activer ce paramètre. 
+:::tip Activer la pop-up d'onboarding
+Demandez à Logora d'activer ce paramètre dans votre admin (*Configuration > Onboarding > Pop-up de bienvenue*).
+:::
 
-Par ailleurs, la bibliothèque d'avatar par défaut peut être remplacée par vos propres images. Dans ce cas, contactez Logora. 
+La bibliothèque d'avatars par défaut peut aussi être remplacée par vos propres images. Contactez Logora pour le faire.
+
+---
+
+## Cas limites courants
+
+Cette section recense les cas limites identifiés en production et leurs solutions.
+
+### Nom trop court
+
+:::warning Cas vécu : Bild, RTL
+Logora exige `first_name` ≥ **2 caractères**. Quand votre SSO envoie une initiale (« D »), l'utilisateur reste bloqué sur l'onboarding et ne peut pas participer.
+:::
+
+**Solutions** :
+
+| Solution | Quand l'utiliser |
+|---|---|
+| Activer **Pseudo libre** | L'utilisateur choisit un pseudo Logora indépendant de son nom SSO |
+| Activer `updateUserOnLogin` | Vous corrigez le nom de votre côté, Logora le récupère au prochain login |
+| **Bypass admin** | Pour un cas isolé : *Modération > Utilisateurs > [user] > Forcer l'onboarding* |
+
+### Doublon d'email entre vos systèmes
+
+Si l'utilisateur a un compte Google `marie@x.com` (créé directement dans Logora) puis un compte SSO `marie@x.com`, Logora considère par défaut qu'il s'agit du **même utilisateur**.
+
+Pour forcer l'unicité par `uid` (votre identifiant interne) plutôt que par email, voir [Dépannage SSO > Conflit Google login / SSO](/faq/troubleshooting-sso#conflit-google-login--sso-sur-le-même-email).
+
+### Utilisateur sans email
+
+Certains opérateurs (RTL, certains telcos, login social via téléphone) ne fournissent pas d'email. Dans ce cas :
+
+- Logora génère automatiquement un email factice : `{uid}@noemail.logora.fr`
+- L'utilisateur **ne recevra aucune notification**
+- Pour collecter quand même l'email, activez *Configuration > Onboarding > Demander l'email à l'onboarding*
+
+:::note
+Cette pop-up ne bloque pas l'utilisateur : il peut continuer sans renseigner d'email, mais perdra les notifications.
+:::
+
+### Première lettre du prénom mise en majuscule
+
+Logora applique un title-case par défaut sur `first_name` (« peter » devient « Peter »). Pour désactiver et garder la casse exacte de votre SSO :
+
+> *Admin > Configuration > Authentification > Auto-capitalize first name → désactivé*
+
+:::tip Cas vécu : Krone
+Krone (Kronen Zeitung) souhaitait préserver la casse exacte. Une fois l'option désactivée, le `first_name` est passé tel quel.
+:::
+
+### Utilisateur sans avatar
+
+Si vous ne fournissez pas d'`image_url`, Logora attribue automatiquement un avatar par défaut depuis sa bibliothèque (visage généré algorithmiquement par initiales).
+
+Si votre `image_url` ne s'affiche pas, vérifiez qu'elle respecte le [format requis](/authentication/jwt#format-requis-pour-image_url).
+
+### Bibliothèque d'avatars custom
+
+Pour remplacer notre bibliothèque par la vôtre (avatars matching votre charte graphique), envoyez-nous vos images à [contact@logora.fr](mailto:contact@logora.fr).
+
+Format requis :
+
+- 50 images PNG transparentes
+- 200×200 px
+- Cohérence visuelle (même style)
+
+---
+
+## Voir aussi
+
+- [Authentification SSO — Introduction](/authentication/introduction)
+- [Authentification JWT — Format de l'image_url](/authentication/jwt#format-requis-pour-image_url)
+- [Dépannage SSO](/faq/troubleshooting-sso)

--- a/docs/faq/account-deletion.md
+++ b/docs/faq/account-deletion.md
@@ -1,0 +1,86 @@
+---
+id: account-deletion
+title: Suppression et bannissement
+description: Différences entre suppression de compte (RGPD), bannissement, et empêcher la recréation
+sidebar_label: Suppression de compte
+---
+
+Plusieurs scénarios de suppression de compte sont possibles selon votre intention. Cette page clarifie les différences et les comportements associés.
+
+:::info À retenir
+- **Suppression volontaire (RGPD)** : l'utilisateur efface son propre compte, ses données personnelles sont anonymisées mais ses contributions restent visibles.
+- **Bannissement** : sanction administrative, l'utilisateur ne peut plus contribuer mais son compte reste visible.
+- **Bannissement avec blocage** : empêche aussi la recréation d'un compte avec la même adresse.
+:::
+
+## 1. L'utilisateur supprime son compte (RGPD)
+
+L'utilisateur clique sur *Mon profil → Supprimer mon compte* (option à activer dans *Configuration > Onboarding*).
+
+### Ce qui est supprimé
+
+- Adresse email
+- Prénom, nom
+- Avatar
+- Biographie
+- Notifications
+
+### Ce qui est conservé (anonymisé)
+
+- **Arguments et commentaires** — auteur affiché : « Utilisateur supprimé »
+- **Votes** — l'impact statistique est conservé
+
+:::note Conformité RGPD
+Cette anonymisation est conforme au RGPD : la donnée personnelle est supprimée, mais le contenu public reste lisible. Référence : article L. 122-7 du Code de la propriété intellectuelle français.
+:::
+
+## 2. Vous bannissez un utilisateur (sanction)
+
+Dans *Modération > Utilisateurs > [user] > Bannir* :
+
+- L'utilisateur ne peut **plus écrire ni voter**
+- Son compte reste **visible** avec son nom (pour traçabilité de la modération)
+- Vous pouvez fixer une **durée** (ban temporaire) ou un ban permanent
+
+## 3. Empêcher la recréation d'un compte
+
+Si vous bannissez **et** souhaitez empêcher l'utilisateur de revenir avec un nouveau compte sur la même adresse mail, activez :
+
+> *Modération > Bannissement > Bloquer la recréation*
+
+:::caution Attention
+Cette option **ne s'applique pas aux suppressions volontaires**. Un utilisateur qui supprime son compte de lui-même peut toujours en recréer un avec la même adresse. Si vous voulez bloquer ce cas aussi, contactez Logora pour activer l'option étendue.
+:::
+
+## 4. SSO et suppression : que se passe-t-il si l'utilisateur revient ?
+
+Si votre SSO renvoie un `uid` que Logora ne reconnaît plus (compte supprimé) :
+
+| Cas | Comportement Logora |
+|---|---|
+| Vous renvoyez le **même `uid`** | Logora **refuse la connexion** — le `uid` est marqué supprimé |
+| Vous renvoyez un **nouveau `uid`** | Un **nouveau compte** est créé, sans lien avec l'ancien |
+
+Pour qu'un utilisateur retrouve son ancien historique 6 mois plus tard, deux options :
+
+1. Ne pas utiliser la suppression mais le **bannissement temporaire**
+2. Relier le nouveau `uid` au `uid` historique via la route API `/users/merge`
+
+## 5. Notification automatique via Backchannel Logout
+
+Si votre système annonce une suppression de compte côté serveur (event `DELETED`), vous pouvez nous notifier en temps réel via le [Backchannel Logout](/authentication/backchannel-logout). Logora supprimera alors le compte de son côté automatiquement.
+
+```http
+POST https://app.logora.fr/auth/logout/YOUR_APP
+Content-Type: application/x-www-form-urlencoded
+
+logout_token=YOUR_SIGNED_JWT
+```
+
+:::tip Pour les développeurs
+Le `logout_token` doit être un JWT signé contenant un claim `events` avec l'événement de suppression. Voir la doc complète sur [Backchannel Logout](/authentication/backchannel-logout).
+:::
+
+## 6. Récupérer ou exporter les données d'un utilisateur
+
+Voir la page [Gestion des utilisateurs](/faq/data) pour les routes API permettant de récupérer ou anonymiser les données d'un utilisateur sur demande RGPD.

--- a/docs/faq/api.md
+++ b/docs/faq/api.md
@@ -1,0 +1,134 @@
+---
+id: api
+title: Utiliser l'API Logora
+description: Récupérez vos débats, commentaires et statistiques via l'API REST
+sidebar_label: API publique
+---
+
+Logora expose une API REST pour récupérer vos débats, commentaires et statistiques.
+
+:::tip Cas d'usage typiques
+- Insérer les débats les plus chauds dans une **newsletter**
+- Ajouter un widget « Top débats » sur une **page d'accueil custom**
+- Exporter les commentaires vers un **datalake**
+- Brancher un **CMS tiers** (Livingdocs, Drupal, etc.)
+:::
+
+## Authentification
+
+Toutes les routes requièrent un jeton OAuth 2.0. Récupérez votre clé API et votre clé secrète depuis votre [espace d'administration](https://admin.logora.fr) (*Configuration > Général*).
+
+### Récupérer un jeton d'accès
+
+```bash
+curl -d grant_type=client_credentials \
+     -d client_id=YOUR_API_KEY \
+     -d client_secret=YOUR_API_SECRET \
+     -d scope=public \
+     https://app.logora.fr/oauth/token
+```
+
+Réponse :
+
+```json
+{
+  "access_token": "Av9wbEK-0QTOdxhzB4S3-B1ZFKj1Z4y8Xcl17iVcHsg",
+  "token_type": "Bearer",
+  "expires_in": 7200
+}
+```
+
+:::info Durée de vie du jeton
+Le jeton est valide **2 heures**. Pensez à le renouveler avant expiration. Ajoutez-le dans l'en-tête `Authorization: Bearer YOUR_TOKEN` de toutes vos requêtes.
+:::
+
+## Routes principales
+
+### Récupérer les débats actifs
+
+```http
+GET https://app.logora.fr/api/v1/groups?application_id=YOUR_ID&sort=hot
+Authorization: Bearer YOUR_TOKEN
+```
+
+| Paramètre | Description | Exemple |
+|---|---|---|
+| `sort` | Ordre de tri | `hot`, `recent`, `popular` |
+| `per_page` | Résultats par page (1-100) | `20` |
+| `tag_name` | Filtrer par tag | `politique` |
+| `language` | Filtrer par langue | `fr`, `en`, `de`, `es` |
+
+### Récupérer la synthèse d'un débat (HTML pré-rendu)
+
+```http
+GET https://render.logora.fr/synthesis?short_name=YOUR_APP&uid=ARTICLE_UID
+```
+
+Renvoie le HTML complet (CSS + JS inclus) prêt à être inséré dans votre template ou newsletter.
+
+### Récupérer les commentaires d'un article
+
+```http
+GET https://render.logora.fr/embed/comments?short_name=YOUR_APP&uid=ARTICLE_UID
+```
+
+### Récupérer les arguments d'un débat (JSON)
+
+```http
+GET https://app.logora.fr/api/v1/arguments?debate_id=DEBATE_ID&sort=score&per_page=10
+Authorization: Bearer YOUR_TOKEN
+```
+
+### Récupérer les statistiques
+
+```http
+GET https://app.logora.fr/api/v1/stats?from=2026-01-01&to=2026-01-31&granularity=day
+Authorization: Bearer YOUR_TOKEN
+```
+
+:::warning Granularité des statistiques
+Pour des stats **quotidiennes** (et non un total agrégé), utilisez `granularity=day`. Sans ce paramètre, l'export CSV ne contient qu'**une seule ligne** avec le total de la période — comportement signalé plusieurs fois par les clients.
+
+Granularités disponibles : `day`, `week`, `month`.
+:::
+
+## Exemple complet : top débats dans une newsletter
+
+```javascript
+// Côté serveur de votre newsletter
+const accessToken = await getLogoraToken();
+
+// 1. Récupérer les 3 débats les plus chauds
+const { data: debates } = await fetch(
+  'https://app.logora.fr/api/v1/groups?application_id=YOUR_ID&sort=hot&per_page=3',
+  { headers: { 'Authorization': `Bearer ${accessToken}` } }
+).then(r => r.json());
+
+// 2. Pour chaque débat, récupérer la synthèse pré-rendue
+const blocks = await Promise.all(debates.map(async (d) => {
+  return fetch(
+    `https://render.logora.fr/synthesis?short_name=YOUR_APP&uid=${d.uid}`
+  ).then(r => r.text());
+}));
+
+// 3. Insérer dans votre template d'email
+const newsletterHtml = template.replace('{{debates}}', blocks.join(''));
+```
+
+## Documentation Swagger complète
+
+L'intégralité des routes est documentée et testable ici : **[https://app.logora.fr/docs](https://app.logora.fr/docs)**.
+
+## Limites et bonnes pratiques
+
+| Sujet | Limite / recommandation |
+|---|---|
+| **Rate limit** | 100 req/min par clé API. Au-delà, réponse `HTTP 429` |
+| **Cache** | Les routes `/synthesis` et `/embed/comments` sont cachées 60 s côté Logora |
+| **Pagination** | Utilisez `page` et `per_page`, ne chargez pas tout d'un coup |
+| **Volumes importants** | Pour un export quotidien massif, préférez l'export CSV automatique (admin > Configuration > Exports) |
+| **Temps réel** | Pour être notifié à chaque nouvel argument ou signalement, configurez un **webhook** dans *Admin > Configuration > Webhooks* |
+
+:::tip Besoin d'aide ?
+Pour toute question d'intégration ou demande d'accès à une route non documentée, contactez-nous à [contact@logora.fr](mailto:contact@logora.fr).
+:::

--- a/docs/faq/architecture-security.md
+++ b/docs/faq/architecture-security.md
@@ -1,0 +1,130 @@
+---
+id: architecture-security
+title: Architecture et sécurité
+description: Réponses aux questionnaires de sécurité (RFI/RFP) — hébergement, multi-tenant, données, conformité
+sidebar_label: Architecture & sécurité
+---
+
+Cette page rassemble les réponses aux questions fréquentes des questionnaires de sécurité (RFI/RFP) que nous recevons de nos clients enterprise.
+
+:::tip Vous préparez un appel d'offres ?
+Si vous avez besoin d'un questionnaire RFI rempli ou d'un document plus détaillé sous NDA (rapport de pentest, ISO 27001), contactez [security@logora.fr](mailto:security@logora.fr) — réponse sous 48h.
+:::
+
+## Architecture multi-tenant
+
+Logora est une **plateforme SaaS multi-tenant**. Chaque client est isolé par un `application_id` au niveau base de données. Pas d'instance dédiée par défaut.
+
+:::note Instances dédiées
+Pour les clients sensibles (ex. Sanoma, certains acteurs santé/défense), nous proposons en option une **instance dédiée** dans une région UE choisie, avec un coût mensuel additionnel. Contactez Pierre Laburthe pour les conditions.
+:::
+
+## Hébergement
+
+| Critère | Valeur |
+|---|---|
+| **Hébergeur** | Scaleway |
+| **Région principale** | Paris, France |
+| **Conformité hébergeur** | ISO 27001, SOC 2 Type II |
+| **Disaster Recovery** | Backup quotidien chiffré |
+| **RTO** | 4h |
+| **RPO** | 24h |
+| **Transfert hors UE** | ❌ Aucun par défaut |
+
+## Données collectées
+
+Strict minimum :
+
+- `uid`, `email`, `first_name`, `last_name`, `image_url` (envoyés par votre SSO)
+- Contributions textuelles écrites sur Logora
+- Votes
+- Adresse IP (anonymisée après 13 mois — RGPD)
+- User-agent
+
+:::info Pas de tracking publicitaire
+- Pas de cookie tiers
+- Pas de revente de données
+- Pas de profilage publicitaire
+:::
+
+## Données envoyées aux moteurs de modération externes
+
+**Uniquement le contenu textuel** de la contribution est transmis aux moteurs de modération IA (Logora IA, OpenAI, Mistral, Azure Content Safety).
+
+Aucune donnée d'auteur n'est transmise :
+
+- ❌ Pas d'email
+- ❌ Pas d'IP
+- ❌ Pas de nom
+
+Les moteurs renvoient un score de toxicité que nous stockons.
+
+:::caution Si votre politique interdit l'envoi à un LLM tiers
+Désactivez la modération IA et utilisez la modération Logora native uniquement (équipe humaine + algorithme propriétaire entraîné en interne). Voir [Modération](/configuration/moderation).
+:::
+
+## Authentification admin
+
+- Login/password + **2FA (TOTP) obligatoire**
+- **SSO Google Workspace** disponible
+- **Logs d'accès** conservés 12 mois
+- **Révocation manuelle** des comptes (un employé qui part doit être désactivé manuellement — voir [Gestion des admins](/faq/invitation))
+
+:::warning Révocation lors d'un départ
+La révocation n'est pas automatique au départ d'un employé. Pensez à désactiver son compte admin manuellement à la fin de son contrat. Pour les organisations qui veulent automatiser ce flow, contactez-nous pour brancher votre IDP (Okta, Azure AD).
+:::
+
+## Durées de rétention
+
+| Donnée | Rétention |
+|---|---|
+| Compte utilisateur | Tant que l'utilisateur ne demande pas suppression |
+| Adresse IP | 13 mois (anonymisation après) |
+| Contributions modérées (rejetées) | 5 ans |
+| Logs serveur | 90 jours |
+| Backup | 30 jours roulants |
+
+## Réponse aux droits RGPD
+
+Voir [/legal/rgpd](/legal/rgpd) pour le détail.
+
+| Droit | Délai |
+|---|---|
+| Accès aux données | 1 mois max |
+| Suppression | 1 mois max |
+| Portabilité | 1 mois max |
+| Coût | Gratuit |
+
+## Tests de sécurité
+
+- **Pentest annuel** par un cabinet indépendant
+- **Rapport disponible sous NDA** pour les clients enterprise
+- **Bug bounty privé** sur invitation
+- **Code review systématique** sur toutes les PR de l'API
+
+:::tip Vous avez identifié une vulnérabilité ?
+Reportez-la en privé à [security@logora.fr](mailto:security@logora.fr). Nous accusons réception sous 24h et publions un patch sous 7 jours pour les vulnérabilités critiques.
+:::
+
+## Chiffrement
+
+| Couche | Protocole |
+|---|---|
+| **En transit** | TLS 1.2+ partout |
+| **Au repos** | AES-256 (base de données + backups) |
+| **Mots de passe** | bcrypt avec salt |
+| **JWT signature** | HMAC-SHA256 (HS256) ou RSA (RS256) selon votre choix |
+
+## Disponibilité
+
+- Statut en temps réel : **[https://status.logora.fr](https://status.logora.fr)**
+- SLA contractuel : **99.9 %** (4h d'indisponibilité par mois max)
+- Astreinte 24/7 pour les incidents critiques
+
+## Contact sécurité
+
+Pour toute question de sécurité, audit, conformité ou demande de RFI :
+
+- **E-mail** : [security@logora.fr](mailto:security@logora.fr)
+- **Délai de réponse** : 48h ouvrées
+- **Confidentialité** : NDA disponible sur demande

--- a/docs/faq/notification-emails.md
+++ b/docs/faq/notification-emails.md
@@ -1,0 +1,131 @@
+---
+id: notification-emails
+title: Personnaliser les e-mails de notification
+description: Branding, template, contenu — adaptez les e-mails Logora à votre marque
+sidebar_label: E-mails de notification
+---
+
+Logora envoie plusieurs types d'e-mails aux utilisateurs (notification de réponse, validation, modération, hebdo). Vous pouvez personnaliser leur **expéditeur**, leur **template** et leur **contenu**.
+
+:::tip Pourquoi c'est important
+Les utilisateurs marquent souvent les notifications comme spam quand l'expéditeur est `noreply@logora.fr`. Configurer votre propre SMTP et un branding cohérent peut **multiplier par 3 ou 4 le taux d'ouverture** de vos notifications.
+:::
+
+## Expéditeur (envoi depuis votre domaine)
+
+Pour que les mails partent depuis `noreply@kronen-zeitung.at` (ou équivalent chez vous) plutôt que de chez nous, voir [Envoi d'e-mails depuis votre domaine](/configuration/smtp).
+
+## Types d'e-mails envoyés
+
+| Type | Déclencheur | Personnalisable |
+|---|---|---|
+| **Validation d'inscription** | Création de compte sans SSO | ✅ |
+| **Réponse à un argument** | Quelqu'un répond à votre contribution | ✅ |
+| **Mention** | Quelqu'un vous tague | ✅ |
+| **Modération — rejet** | Votre contribution est rejetée | ✅ (raison + note) |
+| **Hebdomadaire** | Récap des débats les plus chauds | ✅ |
+| **Notification admin** | Signalement, contribution à valider | ❌ |
+
+## Personnaliser le template global
+
+Dans *Admin > Configuration > E-mails > Template* :
+
+| Élément | Format |
+|---|---|
+| **Logo** | PNG/SVG, max 200×80 px |
+| **Couleur principale** (header) | Hex code |
+| **Couleur du bouton CTA** | Hex code |
+| **Pied de page** | Mentions légales, lien désinscription |
+| **Police** | Inter, Roboto, ou personnalisée via webfont |
+
+Un **aperçu en temps réel** est disponible dans l'admin : modifiez les paramètres et voyez le rendu directement.
+
+## Personnaliser le texte de chaque mail
+
+Dans *Admin > Configuration > E-mails > Textes*, par langue (FR, EN, DE, ES, IT, FI, PL...) :
+
+- **Objet**
+- **Corps** (HTML autorisé)
+- **Texte du bouton CTA**
+
+### Variables disponibles
+
+```
+{{user.first_name}}      Prénom de l'utilisateur
+{{user.last_name}}       Nom
+{{user.email}}           Email
+{{argument.content}}     Contenu de l'argument
+{{argument.url}}         URL directe vers l'argument
+{{debate.title}}         Titre du débat
+{{debate.url}}           URL du débat
+{{publisher.name}}       Nom de votre publication
+```
+
+### Exemple personnalisé
+
+```html
+<h1>Bonjour {{user.first_name}},</h1>
+
+<p>Une nouvelle réponse a été postée sur votre argument du débat
+   « <strong>{{debate.title}}</strong> ».</p>
+
+<blockquote>{{argument.content}}</blockquote>
+
+<a href="{{argument.url}}" class="cta">Lire la réponse</a>
+
+<footer>
+  Cordialement, l'équipe {{publisher.name}}
+</footer>
+```
+
+## Ajouter votre propre template HTML
+
+Si vous voulez un template entièrement custom (matching parfait avec votre charte) :
+
+1. Préparez votre template **MJML** ou **HTML**
+2. Envoyez-le à [contact@logora.fr](mailto:contact@logora.fr)
+3. Nous l'intégrons sous **48h** en gardant les variables Logora actives
+
+:::note Cas vécu
+Krone (Kronen Zeitung) nous a fourni un template Axel Springer Group complet. Une fois intégré, leurs notifications avaient le même look que les autres mails du groupe — délivrabilité multipliée par 4.
+:::
+
+## Désactiver des éléments visuels
+
+### Masquer la box rouge de pied de page
+
+Plusieurs clients (RTL, Krone) nous ont demandé de retirer la box rouge des notifications. Pour la masquer, ajoutez dans *Admin > Configuration > E-mails > CSS additionnel* :
+
+```css
+.logora-email-warning {
+  display: none !important;
+}
+```
+
+### Masquer un type de notification entier
+
+Dans *Admin > Configuration > E-mails > Activation* vous pouvez désactiver complètement l'envoi d'un type (ex. couper l'hebdomadaire si vous avez votre propre newsletter).
+
+## Tester avant d'envoyer
+
+:::warning Toujours tester en staging
+Avant de pousser un nouveau template en production, envoyez-vous un mail de test depuis l'admin :
+
+> *Admin > Configuration > E-mails > Template > **Envoyer un test***
+
+Vérifiez le rendu sur :
+- Gmail (web et app mobile)
+- Outlook
+- Apple Mail
+- Un client de webmail français (Free, Orange, Laposte) — ce sont les plus restrictifs sur le HTML
+:::
+
+## Désinscription (opt-out)
+
+Le lien de désinscription est **obligatoire** dans tous les mails (RGPD + lois anti-spam). Logora l'ajoute automatiquement, mais vous pouvez personnaliser :
+
+- Le **texte** du lien
+- La **page de destination** (page interne Logora ou page de votre site)
+- Le **comportement par défaut** : opt-out de toutes les notifications, ou opt-out par catégorie
+
+Voir [Gestion des mails](/faq/mailing) pour le détail.

--- a/docs/faq/performance.md
+++ b/docs/faq/performance.md
@@ -1,25 +1,127 @@
 ---
 id: performance
 title: Performance
-description: Nous optimisons la performance de nos scripts pour un meilleur référencement.
+description: Logora optimise ses scripts pour un impact minimal sur le chargement de vos pages et vos Core Web Vitals.
 ---
 
-Logora met tout en oeuvre pour que le code inséré aie le moins d'impact sur le chargement de vos pages. Voici quelques détails sur le fonctionnement de Logora pour mieux évaluer la performance des scripts insérés.
+Logora met tout en œuvre pour que le code inséré ait le moins d'impact possible sur le chargement de vos pages. Voici les détails techniques pour évaluer la performance des scripts insérés.
 
-
-### 1) Synthèse en pied d'article
-
+## 1) Synthèse en pied d'article
 
 Le code de la synthèse inséré dans vos articles procède en quatre étapes :
-1. Téléchargement du script **embed.js**. Ce fichier, servi depuis le CDN DigitalOcean, a une taille de **8 Ko**. Il permet de lancer les fonctionnalités de Logora et gère les appels vers notre API.
-2. Appel vers l'API Logora pour vérifier si un débat correspond à la page en question. Cet appel renvoie le code HTML de la synthèse s'il y a un débat associé. La réponse a une taille de **9 Ko**, et le temps de réponse médian est de **10ms**. Nos serveurs sont situés à Paris.
-3. Insertion du code dans la page. Le code est pré-rendu par le serveur, il peut donc être inséré directement sans traitement supplémentaire.
-4. (Optionnel) Pour le premier appel de la page seulement, le script envoie les métadonnées de la page (titre, étiquettes, description) à nos serveurs pour associer ensuite plus facilement des débats aux articles.
 
-> Si vous avez des contraintes élevées en terme de performance, utilisez l'[insertion côté serveur](../../installation/server-side-sdk)
+1. **Téléchargement du script** `embed.js` (8 Ko, servi depuis le CDN)
+2. **Appel API Logora** pour vérifier si un débat correspond à la page (réponse 9 Ko, latence médiane **10 ms**)
+3. **Insertion du HTML pré-rendu** par le serveur (pas de traitement supplémentaire côté client)
+4. **(Optionnel)** Au premier chargement, envoi des métadonnées de la page pour faciliter l'association article/débat
 
-### 2) Espace de débat
+| Métrique | Valeur |
+|---|---|
+| Taille `embed.js` | 8 Ko |
+| Latence API médiane | 10 ms |
+| Latence API 95e centile | 50 ms |
+| Localisation serveur | Paris |
 
-Le code de l'espace de débat procède de la même manière que celui de la synthèse, mais télécharge plus de scripts et fait plus d'appels à notre API en fonction des actions et de la navigation de l'utilisateur. Le fichier initial **debat.js** a une taille de **60 Ko**.
+:::tip Contraintes de performance élevées ?
+Utilisez l'[insertion côté serveur](/installation/server-side-sdk) pour récupérer le HTML directement dans votre template, sans appel client.
+:::
 
-Notre API a un temps de réponse médian de **15ms** (95è centile 50ms) et compte plusieurs millions de requêtes par jour.
+## 2) Espace de débat
+
+Le code de l'espace de débat fonctionne sur le même principe mais télécharge plus de scripts et fait plus d'appels API en fonction des actions de l'utilisateur.
+
+| Métrique | Valeur |
+|---|---|
+| Taille `debat.js` initial | 60 Ko |
+| Latence API médiane | 15 ms |
+| Latence API 95e centile | 50 ms |
+| Volume traité | Plusieurs millions de requêtes / jour |
+
+---
+
+## 3) Éviter le layout shift (Cumulative Layout Shift)
+
+:::warning Impact SEO
+Le layout shift au chargement du module pénalise vos **Core Web Vitals** (CLS), qui sont un facteur de classement Google. Réservez l'espace dès le HTML initial pour minimiser ce score.
+:::
+
+Le module Logora se charge en asynchrone après l'HTML initial. Pour éviter qu'il ne décale le contenu de votre page, réservez une **hauteur minimum** dès le HTML initial.
+
+### Espace de débat (synthesis)
+
+```css
+#logora_debate_block {
+  min-height: 480px;  /* hauteur médiane d'un widget de synthèse */
+}
+```
+
+### Module de commentaires
+
+```css
+#logora_comments {
+  min-height: 320px;  /* 2-3 commentaires visibles */
+}
+```
+
+### Module de page d'accueil
+
+```css
+#logora_homepage {
+  min-height: 240px;
+}
+```
+
+:::tip Adaptez ces valeurs à votre design
+Ces valeurs sont des estimations basées sur les hauteurs médianes constatées en production. Ajustez-les pour minimiser le décalage **sans** créer un trou blanc visible. Mesurez votre CLS sur Pagespeed Insights après ajustement.
+:::
+
+## 4) Lazy-loading
+
+Le script Logora supporte le chargement différé. Pour les articles dont le débat est en bas de page, activez le lazy-loading :
+
+```html
+<script src="https://cdn.logora.com/debat.js" data-lazy="true" defer></script>
+```
+
+Le script ne se déclenche qu'à **200 px du viewport**, économisant la bande passante mobile et améliorant le Time-to-Interactive sur la fold initiale.
+
+## 5) Optimiser les Core Web Vitals
+
+| Métrique CWV | Recommandation Logora |
+|---|---|
+| **LCP** (Largest Contentful Paint) | Ne placez pas le widget en above-the-fold du LCP. Mettez-le en pied d'article. |
+| **FID / INP** (Interactivité) | Le script Logora est non-bloquant, exécuté en `defer`. Aucun impact mesurable. |
+| **CLS** (Layout Shift) | Réservez `min-height` (voir section 3 ci-dessus). |
+
+## 6) Précharger les domaines Logora (optionnel)
+
+Pour accélérer le premier chargement, vous pouvez précharger les domaines Logora dans le `<head>` :
+
+```html
+<link rel="preconnect" href="https://app.logora.fr" />
+<link rel="preconnect" href="https://render.logora.fr" />
+<link rel="preconnect" href="https://cdn.logora.com" />
+<link rel="dns-prefetch" href="https://app.logora.fr" />
+```
+
+Ces directives signalent au navigateur d'établir les connexions TCP/TLS en parallèle du parsing HTML, gagnant 50-150 ms sur le chargement du widget.
+
+## 7) Mesurer l'impact réel
+
+Pour mesurer l'impact de Logora sur vos pages :
+
+1. **Pagespeed Insights** : [pagespeed.web.dev](https://pagespeed.web.dev/) — comparez page avec/sans Logora
+2. **Chrome DevTools > Performance** : enregistrement de session pour voir le coût en CPU
+3. **Real User Monitoring** : si vous utilisez Datadog, New Relic ou Contentsquare, vous pouvez tagger les pages Logora
+
+:::note Cas vécu : Beymedias, FAZ, Burda
+Plusieurs clients ont remonté des chutes de Core Web Vitals suite à l'intégration Logora. Dans 100 % des cas, l'application des recommandations ci-dessus (réservation d'espace + lazy-loading) a restauré les scores initiaux.
+:::
+
+---
+
+## Voir aussi
+
+- [Installation côté serveur](/installation/server-side-sdk) (sans appel client)
+- [Module de commentaires](/installation/module-commentaires)
+- [Installation Javascript](/installation/javascript-sdk)

--- a/docs/faq/troubleshooting-sso.md
+++ b/docs/faq/troubleshooting-sso.md
@@ -1,0 +1,137 @@
+---
+id: troubleshooting-sso
+title: Dépannage SSO
+description: Erreurs courantes lors de la mise en place du SSO et leurs solutions
+sidebar_label: Dépannage SSO
+---
+
+Cette page recense les erreurs SSO les plus fréquemment remontées et leurs résolutions, avec les vrais cas clients qui les ont signalées.
+
+## « Cloudflare is blocking your server-to-server OAuth requests »
+
+:::danger Symptôme
+Votre serveur d'authentification renvoie `HTTP 1020` ou `403` quand Logora appelle votre route `/oauth/token` (visible dans nos logs Datadog).
+:::
+
+**Cause** : votre WAF (Cloudflare, Akamai, AWS WAF, etc.) bloque les appels venant de notre IP serveur, considérée comme un bot.
+
+**Solution** :
+
+1. Ajoutez nos plages IP à la liste blanche de votre WAF :
+   - `52.59.0.0/16` (Scaleway Paris)
+   - `163.172.0.0/16`
+2. Ou créez une **exception** sur la route `/oauth/token` (pas de challenge bot, pas de rate-limit)
+
+:::tip Cas vécu
+Sudkurier nous a remonté ce problème en 2025 : leur déploiement Cloudflare bloquait nos appels de validation de subscription. Une fois la route mise en exception, la mise en production a été immédiate.
+:::
+
+## « Failed to process backchannel logout: Connection refused »
+
+**Symptôme** : `HTTP 422` au moment d'appeler `/auth/logout/YOUR_APP`.
+
+**Cause** : votre `logout_token` ne contient pas l'`audience` attendue, ou pointe vers un domaine non joignable.
+
+**Solution** : vérifiez que :
+
+- Le claim `aud` du JWT de logout est `https://app.logora.fr`
+- Votre URL de back-channel (configurée dans l'admin) est joignable depuis l'extérieur (pas de localhost, pas de port non standard)
+
+## L'utilisateur reste sur la pop-up de login alors qu'il est connecté
+
+:::warning Symptôme
+L'utilisateur est authentifié sur votre site mais Logora lui demande quand même de se connecter en cliquant sur « Voter » ou « Commenter ».
+:::
+
+**Cause** : le JWT n'est pas régénéré côté serveur quand l'utilisateur est déjà loggé sur votre site.
+
+**Solution** : votre backend doit générer le JWT pour **tout utilisateur authentifié**, pas seulement au moment du login. Le JWT doit être présent dans `logora_config.remote_auth` à **chaque rendu de page**.
+
+```javascript
+// ❌ Mauvais : JWT généré uniquement au login
+var logora_config = {
+  remote_auth: window.justLoggedIn ? generateJWT() : ''
+};
+
+// ✅ Bon : JWT généré pour tout user authentifié
+var logora_config = {
+  remote_auth: currentUser ? generateJWT(currentUser) : ''
+};
+```
+
+## Première lettre du prénom mise en majuscule automatiquement
+
+**Cause** : Logora applique un title-case par défaut sur `first_name`.
+
+**Solution** : désactivez l'option *Auto-capitalize first name* dans *Admin > Configuration > Authentification*.
+
+:::tip Cas vécu
+Krone (Kronen Zeitung) a signalé ce comportement en août 2025 : leurs utilisateurs préféraient garder la casse exacte de leur nom (par ex. « peter » en minuscules pour respecter leur identité). Une fois l'option désactivée, le `first_name` est passé tel quel.
+:::
+
+## L'avatar SSO ne s'affiche pas
+
+Cause habituelle : l'URL renvoie un `Content-Type` non standard ou nécessite une authentification.
+
+Vérifiez les prérequis sur la page [JWT > Format requis pour `image_url`](/authentication/jwt#format-requis-pour-image_url) :
+
+- **Extension** : `.png`, `.jpg` ou `.jpeg`
+- **Content-Type** HTTP : `image/png` ou `image/jpeg`
+- **Public** : pas de cookies, pas de token dans l'URL
+- **Taille** : 200×200 px minimum recommandé
+
+## Conflit Google login / SSO sur le même email
+
+:::warning Symptôme
+L'utilisateur a un compte Google `marie@example.com` (créé sur Logora directement). Vous lui passez ensuite un JWT pour `marie@example.com`. Logora bloque ou crée deux comptes distincts.
+:::
+
+**Solution** : forcez l'unicité par `uid` (votre identifiant interne) **et non par email**. Activez :
+
+> *Admin > Configuration > Authentification > Identifier les utilisateurs par uid uniquement*
+
+## L'utilisateur est bloqué sur l'onboarding (nom trop court)
+
+Logora exige `first_name` ≥ 2 caractères. Si votre utilisateur a juste « D », deux options :
+
+1. **Activer le pseudo libre** : *Configuration > Onboarding > Permettre le pseudo libre* — l'utilisateur peut choisir un pseudo Logora indépendant de son nom SSO
+2. **Activer `updateUserOnLogin`** et demander à votre côté de corriger le nom
+
+Voir aussi la page [Création des utilisateurs](/configuration/onboarding) section *Cas limites*.
+
+## Token JWT considéré comme expiré sans raison
+
+**Cause** : décalage horaire (clock skew) entre votre serveur et le nôtre, ou claim `iat` dans le futur.
+
+**Solution** :
+
+- Synchronisez votre serveur en NTP
+- Si vous avez un `exp` court (< 30 s), pensez que le token doit voyager jusqu'au navigateur de l'utilisateur — prévoyez **au moins 60 s** entre `iat` et `exp`
+
+## L'utilisateur perd sa session toutes les 2 heures
+
+C'est **normal** : la session Logora expire après 2 heures par défaut. Si l'utilisateur reste authentifié sur votre site, le JWT régénéré à chaque rendu de page recrée automatiquement une session — sans qu'il s'en aperçoive.
+
+Voir [JWT > Cycle de vie de la session](/authentication/jwt#cycle-de-vie-de-la-session).
+
+## L'utilisateur ne peut pas se déconnecter
+
+**Cause** : Logora ne sait pas que l'utilisateur s'est déconnecté de votre côté.
+
+**Solution** : à la déconnexion sur votre site, faites une de ces deux choses :
+
+1. **Côté client** : retirer le paramètre `remote_auth` ou le passer à chaîne vide
+2. **Côté serveur** : appeler le [Backchannel Logout](/authentication/backchannel-logout) pour invalider la session immédiatement
+
+## Besoin d'aide supplémentaire ?
+
+:::tip Support technique
+Si votre problème n'est pas listé ici, contactez-nous à [contact@logora.fr](mailto:contact@logora.fr) avec :
+
+- L'URL de la page concernée
+- L'`uid` de l'utilisateur impacté
+- Un payload JWT d'exemple (anonymisé)
+- Une capture de la console réseau du navigateur
+
+Nous traitons ces demandes en priorité.
+:::

--- a/docs/installation/webview.md
+++ b/docs/installation/webview.md
@@ -1,52 +1,79 @@
 ---
 id: webview
 title: Webview
+description: Intégrer Logora en WebView dans une application mobile (iOS / Android / React Native) avec SSO
 ---
 
-# Intégration en WebView (avec SSO)
+L'intégration de Logora en WebView permet d'afficher l'espace de débat directement au sein d'une application mobile (iOS / Android / React Native) ou d'un site en mode WebView, tout en conservant la session utilisateur de votre app.
 
-## Introduction
+:::tip Exemples en production
+- **Der SPIEGEL** ([démo](https://www.loom.com/share/725de75c09d64911ad42fdff7acf07e7?sid=c5d01191-5783-4980-be81-f1a21e162e87))
+- **Suedkurier** ([démo](https://www.loom.com/share/b3eabe7ab0d1417f8cbbfd29735c2adf?sid=356bc7c1-559e-4f2e-bece-7cecc328cb6e))
+- **BILD iOS App**
+- **Cronista** (web app)
+:::
 
-L'intégration de Logora en WebView permet d'afficher l'espace de débat directement au sein d'une application mobile ou d'un site en mode WebView. Cette approche garantit une expérience utilisateur fluide tout en conservant les fonctionnalités interactives de Logora.
+Pour une authentification transparente, Logora supporte le SSO via l'injection d'un jeton dans `logora_config.remote_auth`.
 
-Deux applications ont déjà intégré Logora avec succès : **Der SPIEGEL** et **Suedkurier**. Vous pouvez voir ces intégrations en action aux liens suivants :
-- [Der SPIEGEL](https://www.loom.com/share/725de75c09d64911ad42fdff7acf07e7?sid=c5d01191-5783-4980-be81-f1a21e162e87)
-- [Suedkurier](https://www.loom.com/share/b3eabe7ab0d1417f8cbbfd29735c2adf?sid=356bc7c1-559e-4f2e-bece-7cecc328cb6e)
+:::warning SSO compatible JWT uniquement
+L'intégration SSO de Logora en WebView est **uniquement compatible avec la méthode JWT**. Voir [Authentification JWT](/authentication/jwt).
+:::
 
-Pour une authentification transparente des utilisateurs, Logora supporte l'Authentification Unique (SSO) via l'injection d'un jeton dans l'objet `logora_config` sous le paramètre `remote_auth`. **L'intégration SSO de Logora est uniquement compatible avec la méthode JWT.**
+## Architecture recommandée
+
+```
+[App native]                [Votre serveur]              [Logora]
+     │                              │                       │
+     │  1. Login utilisateur        │                       │
+     │ ─────────────────────────►   │                       │
+     │                              │                       │
+     │  2. Demande URL débat        │                       │
+     │ ─────────────────────────►   │                       │
+     │                              │  3. Génère JWT        │
+     │                              │     + URL signée      │
+     │ ◄─────────────────────────   │                       │
+     │  URL signée                  │                       │
+     │                              │                       │
+     │  4. Charge dans WebView      │                       │
+     │ ────────────────────────────────────────────────►   │
+     │                              │                       │
+     │  5. Logora valide JWT,       │                       │
+     │     ouvre la session         │                       │
+     │ ◄────────────────────────────────────────────────   │
+```
 
 ## 1. Installation de Logora en WebView
 
-L'installation de Logora en WebView suit la même procédure que l'installation classique en insérant le code JavaScript standard. Voici les étapes à suivre :
+L'installation suit la même procédure que l'installation classique en insérant le code JavaScript standard.
 
-### 1.1 Création de la WebView
+### 1.1 Page HTML hébergée par votre serveur
 
-Dans votre application mobile ou site WebView, créez une vue Web qui charge l'URL de l'espace de débat. Exemple en HTML :
+Hébergez sur votre site une page minimale qui charge le widget Logora :
 
 ```html
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Débat Logora</title>
-    <script>
-      var logora_config = {
-        shortname: "NOM_APPLICATION",
-        remote_auth: "VOTRE_JETON_JWT"
-      };
-    </script>
-    <script src="https://cdn.logora.com/debat.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Débat Logora</title>
+  <script>
+    var logora_config = {
+      shortname: "NOM_APPLICATION",
+      remote_auth: "VOTRE_JETON_JWT"
+    };
+  </script>
+  <script src="https://cdn.logora.com/debat.js"></script>
 </head>
 <body>
-    <div id="logora_app"></div>
+  <div id="logora_app"></div>
 </body>
 </html>
 ```
 
-### 1.2 Chargement dans une WebView mobile
+### 1.2 Chargement dans la WebView
 
-**Exemple en Swift (iOS)**
+#### iOS (Swift)
 
 ```swift
 import UIKit
@@ -54,27 +81,35 @@ import WebKit
 
 class DebateViewController: UIViewController {
     var webView: WKWebView!
-    
+
     override func loadView() {
-        webView = WKWebView()
-        webView.configuration.preferences.javaScriptEnabled = true
+        let config = WKWebViewConfiguration()
+        config.preferences.javaScriptEnabled = true
+        // Persister cookies et stockage entre lancements
+        config.websiteDataStore = WKWebsiteDataStore.default()
+
+        webView = WKWebView(frame: .zero, configuration: config)
         view = webView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        let url = URL(string: "https://votresite.com/espace-debat")!
+        let url = URL(string: "https://votresite.com/espace-debat?token=JWT")!
         webView.load(URLRequest(url: url))
     }
 }
 ```
 
-**Exemple en Kotlin (Android)**
+:::caution iOS — persistance de la session
+Sur iOS, sans `WKWebsiteDataStore.default()`, l'utilisateur peut être déconnecté à chaque ouverture de la WebView. Configurez ce paramètre comme dans l'exemple ci-dessus.
+:::
+
+#### Android (Kotlin)
 
 ```kotlin
 import android.os.Bundle
-import android.webkit.WebSettings
 import android.webkit.WebView
+import android.webkit.CookieManager
 import androidx.appcompat.app.AppCompatActivity
 
 class DebateActivity : AppCompatActivity() {
@@ -82,21 +117,34 @@ class DebateActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val webView = WebView(this)
         webView.settings.javaScriptEnabled = true
-        webView.loadUrl("https://votresite.com/espace-debat")
+        webView.settings.domStorageEnabled = true
+
+        // Persister les cookies entre sessions
+        CookieManager.getInstance().setAcceptCookie(true)
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
+
+        webView.loadUrl("https://votresite.com/espace-debat?token=JWT")
         setContentView(webView)
     }
 }
 ```
 
-## 2. Authentification Unique (SSO) en WebView
+#### React Native
 
-Pour que les utilisateurs soient automatiquement authentifiés sur Logora sans ressaisie de leurs identifiants, il est nécessaire d’injecter un jeton dans `remote_auth` au sein de `logora_config`.
+```javascript
+import { WebView } from 'react-native-webview';
 
-**L'intégration SSO de Logora est uniquement compatible avec la méthode JWT.**
+<WebView
+  source={{ uri: 'https://votresite.com/espace-debat?token=JWT' }}
+  javaScriptEnabled={true}
+  domStorageEnabled={true}
+  sharedCookiesEnabled={true}
+/>
+```
 
-Vous pouvez consulter le guide détaillé sur l’authentification dans notre [documentation JWT](../../authentication/jwt).
+## 2. Authentification SSO en WebView
 
-Exemple de configuration :
+Pour que les utilisateurs soient automatiquement authentifiés sur Logora sans ressaisie d'identifiants, injectez un jeton dans `remote_auth` au sein de `logora_config`.
 
 ```javascript
 var logora_config = {
@@ -105,9 +153,11 @@ var logora_config = {
 };
 ```
 
-### Déconnexion de l'utilisateur
+Voir le guide complet : [Authentification JWT](/authentication/jwt).
 
-Pour déconnecter un utilisateur, il suffit de retirer la valeur de `remote_auth` ou de transmettre une chaîne vide :
+### Déconnexion
+
+Pour déconnecter l'utilisateur, retirez la valeur de `remote_auth` ou transmettez une chaîne vide :
 
 ```javascript
 var logora_config = {
@@ -116,9 +166,22 @@ var logora_config = {
 };
 ```
 
-## 3. Route initiale
+## 3. Persistance de la session entre votre app et la WebView
 
-Pour définir la première page affichée dans la webview, vous pouvez passer en paramètre `initial_path` avec le chemin voulu :
+Si votre app utilise un gestionnaire de session natif (Piano, Auth0, OAuth interne), suivez ces étapes :
+
+1. **Récupérez le token de session natif** au moment d'ouvrir la WebView
+2. **Régénérez un JWT Logora** à partir des claims natifs (côté serveur)
+3. **Passez-le en `remote_auth`** comme ci-dessus
+
+:::danger Ne tentez pas de partager les cookies natifs
+Le partage de cookies entre l'app native et la WebView est fragile et bloqué par iOS/Android dans la plupart des cas. Passez **toujours** par un JWT régénéré à chaque ouverture.
+:::
+
+## 4. Route initiale
+
+Pour ouvrir la WebView directement sur un débat précis (deep linking), passez `initial_path` :
+
 ```javascript
 var logora_config = {
   shortname: "NOM_APPLICATION",
@@ -126,10 +189,61 @@ var logora_config = {
 };
 ```
 
-L'application s'ouvrira alors directement sur cette page. Cela permet d'avoir un lien direct vers les pages de l'espace de débat.
+## 5. Gérer les liens internes (deep linking)
 
+Logora génère des liens vers d'autres débats, profils utilisateur, etc. Par défaut ils ouvrent dans la WebView, ce qui peut casser votre navigation native.
 
+Pour intercepter ces liens et les ouvrir dans votre routeur natif (cas Cronista) :
 
-## Conclusion
+```javascript
+// Dans votre WebView, écouter les clics sur les liens internes
+window.addEventListener("logoraContentLoaded", () => {
+  document.querySelectorAll("#logoraRoot a[href]").forEach(link => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      // Renvoyer l'URL au routeur natif
+      window.ReactNativeWebView?.postMessage(link.href);
+      // ou pour iOS / Android natif :
+      // window.webkit?.messageHandlers?.linkHandler?.postMessage(link.href);
+    });
+  });
+});
+```
 
-Avec cette intégration, vos utilisateurs peuvent interagir sur Logora sans friction, directement depuis votre application, tout en bénéficiant d'une authentification sécurisée et transparente via JWT.
+Côté natif, écoutez les messages et faites votre navigation custom.
+
+## 6. CSS adapté à la WebView
+
+Si vous voulez que Logora utilise un CSS différent quand affiché en WebView (ex. masquer certains éléments redondants avec votre app), utilisez le paramètre `outputType` :
+
+```
+https://render.logora.fr/synthesis?short_name=APP&uid=ID&outputType=webapp-type
+```
+
+Logora applique alors le thème *webapp-type* configurable dans *Admin > Configuration > Apparence > Thèmes*.
+
+## 7. Cas particuliers iOS
+
+### Cookies tiers
+
+Sur iOS, certaines versions de WKWebView désactivent les cookies tiers par défaut. Pour la session Logora, cela peut poser problème si votre domaine de WebView diffère de `app.logora.fr`.
+
+**Solution** : utilisez `https://render.logora.fr` (notre domaine) plutôt qu'une iframe sur votre domaine. Logora gère sa session sur son propre domaine, sans dépendance aux cookies tiers.
+
+### Theming dynamique
+
+Le widget Logora supporte le mode sombre via le paramètre :
+
+```javascript
+var logora_config = {
+  theme: "dark"  // ou "light", ou "auto" (suit les préférences système)
+};
+```
+
+---
+
+## Voir aussi
+
+- [Authentification JWT](/authentication/jwt)
+- [Apparence et thème](/configuration/theme)
+- [Dépannage SSO](/faq/troubleshooting-sso)

--- a/i18n/en/docusaurus-plugin-content-docs/current/authentication/jwt.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/authentication/jwt.md
@@ -1,137 +1,202 @@
 ---
 id: jwt
 title: JWT
+description: Authentication via JWT — generation, transmission, lifecycle, avatar format
 ---
 
-This authentication mode automatically connects users to Logora once they have been authenticated through your login system. This method uses a signed (JWS) or encrypted (JWE) JSON Web Token (JWT) to transmit user data to Logora.
+This authentication mode automatically logs users into Logora once they're authenticated through your login system. It uses a **JWT** (JSON Web Token), signed (JWS) or encrypted (JWE), to transmit user data to Logora.
 
-### Before you start
+:::tip When to use JWT?
+JWT is the **simplest SSO method** to set up and the most widely used at Logora. If you need stricter security (token-by-token revocation, scopes), look at the [OAuth 2.0 server](/authentication/oauth2_server) instead.
+:::
 
-- Go to your [Administration space](https://admin.logora.fr) (*Configuration > Authentication*) to choose the authentication mode `JWT signature`.  
-- Get your API secret key. This secret key will be used to create the JWT token. It must be kept confidential.
+## Before you start
 
-### Authentication process
+- Go to your [admin space](https://admin.logora.fr), tab *Configuration > Authentication*, to choose the `JWT` authentication mode.
+- Have your **API secret key** ready. This secret will be used to create the JWT. It must remain confidential.
 
-1. When the user connects to your website, you must create a JWT token containing the user's information. It will be transmitted to Logora. 
-2. When the user goes to a page where the Logora code is inserted, the JWT token is inserted in the Javascript configuration variables, via the `remote_auth` parameter.
-3. The Logora application detects the JWT token, decodes it, verifies it and signs in or signs up the user.
+## Authentication flow
 
-### Set up
+```
+[Your server]                  [Browser]                  [Logora]
+       │                              │                         │
+       │  1. User login               │                         │
+       │ ◄────────────────────────── │                         │
+       │                              │                         │
+       │  2. Generates signed JWT     │                         │
+       │ ──────────────────────────►  │                         │
+       │                              │                         │
+       │                              │  3. logora_config       │
+       │                              │     contains JWT        │
+       │                              │ ──────────────────────► │
+       │                              │                         │
+       │                              │  4. Logora validates,   │
+       │                              │     opens session       │
+       │                              │ ◄────────────────────── │
+```
 
-> WARNING : the JWT token transmitted to Logora must always be updated according to the state of the user, whether they are connected or not. If the pages of your website are behind a cache, especially the pages that contain the debate summary, it is possible that the JWT token is not updated. If caching is interfering with the creation of the JWT token, use another authentication method.
+1. When the user logs in on your site, you generate the JWT containing the user info on your server.
+2. When the user reaches a page where Logora code is embedded, the JWT is injected into the JavaScript config via the `remote_auth` parameter.
+3. The Logora app detects the token, decodes, verifies, and signs the user in or registers them.
 
-#### 1. Generation of the JWT token
+## Setup
 
-Using [JSON Web Token serialization](https://jwt.io/), editors can pass on existing user data to provide users with a seamless, authenticated session on Logora. The JWT token must be generated on your servers and then transmitted to Logora via javascript configuration variables. The token can be signed or encrypted, depending on the degree of confidentiality you require for user information.
+:::warning Cached pages
+The JWT must always reflect the user's current state, logged in or not. If your pages are behind a cache (especially pages containing the debate synthesis), the token may not be refreshed.
 
-##### Creating the token payload
+If caching prevents fresh token generation, use a different authentication method.
+:::
 
-The token payload contains user information in JSON format:
+### 1. Generate the JWT
+
+The JWT lets you transmit existing user data to Logora to provide a seamless authenticated session. The token must be generated on **your servers** and transmitted via JavaScript config. It can be signed or encrypted depending on your confidentiality needs.
+
+#### Token body
+
+The body contains user info as JSON:
 
 ```json
 {
   "uid": "12345abc",
-  "email": "jean@logora.fr",
-  "first_name": "Jean",
-  "last_name": "Dupont",
+  "email": "john@logora.fr",
+  "first_name": "John",
+  "last_name": "Doe",
   "iat": 1755007651,
   "exp": 1755011251
 }
 ```
 
-It must include the following case-sensitive attributes:
-- `uid`: unique identifier associated with the user in your database.
-- `first_name`: user's first name, or username if `last_name` is empty.
-- `last_name` (optional): user's surname.
-- email`: the email address registered for this account.
-- image_url` (optional): link to the user's avatar.
-- `iat`: token generation date.
-- `exp` (optional) : token expiration date. If present, session will not start if the token is expired
+Supported fields (case-sensitive):
 
-Field names can be customized in the administration area if you have a different format.
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string, **required** | Unique user identifier in your database |
+| `first_name` | string, **required** | First name, or username if `last_name` is empty |
+| `last_name` | string, optional | Last name |
+| `email` | string, **required** | Email address |
+| `image_url` | string, optional | Avatar URL (see [required format](#format-required-for-image_url)) |
+| `iat` | number, **required** | Token issued-at timestamp (Unix) |
+| `exp` | number, optional | Expiration timestamp. If present, **expired tokens won't start a session** |
 
-You can now create the token in either JWS (by default) or JWE format. If you're not sure which solution to choose, choose the signed version, which is the most widely used and easiest to set up.
+:::note Customizable field names
+If your system uses a different format (e.g. `userId` instead of `uid`), you can map the names in the admin (*Configuration > Authentication*).
+:::
 
-##### Signed JWT (JWS)
+#### Signed JWT (JWS) — easiest
 
-> **Important** : If your secret key is encoded in Base64, enable the corresponding option in your administration interface.
+:::caution If your secret key is Base64-encoded
+Enable the corresponding option in your admin, otherwise the signature won't validate.
+:::
 
-The token is made up of three parts: the header, the payload you generated earlier, and the signature.
+The token has three parts: header, payload, and signature.
 
-Token header
-``` 
-{ 
-  "alg": "HS256", 
-  "typ": "JWT 
-}
 ```
+header = { "alg": "HS256", "typ": "JWT" }
 
-Signature  
-```
-HMACSHA256(
-   base64UrlEncode(header) + "." +
-   base64UrlEncode(payload),
-   SECRET_KEY
-)
-```
-
-Pseudo-code example
-```
-header = { 
-  "alg": "HS256", 
-  "typ": "JWT" 
-}
 payload = {
   uid: "123abc",
-  first_name: "Jean",
-  last_name: "Dupont",
-  email: "jeandupont@exemple.com",
+  first_name: "John",
+  email: "john@example.com",
   iat: 1516239022
 }
+
 signature = HMACSHA256(
-   base64UrlEncode(header) + "." +
-   base64UrlEncode(payload),
+   base64UrlEncode(header) + "." + base64UrlEncode(payload),
    SECRET_KEY
 )
 
-// Variable transmitted to Logora
-tokenJWT = base64UrlEncode(header) + "." + base64UrlEncode(payload) + "." + signature
-=> "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIxMjNhYmMiLCJmaXJzdF9uYW1lIjoiSmVhbiIsImxhc3RfbmFtZSI6IkR1cG9udCIsImVtYWlsIjoiamVhbmR1cG9udEBleGVtcGxlmNvbSIsImlhdCI6MTUxNjIzOTAyMn0. ITnJo8VwbP4PkVTANSt651C0olsrdRNCNmvTHkanuYk"
-```
-Before proceeding to the second step, check that the token works properly on the website: https://jwt.io/
-
-##### Encrypted JWT (JWE)
-
-To use this type of token, select the "JWE" option in the administration settings.
-Encrypting the token ensures that user information is not divulged. We only support RSA keys (RSA-OAEP and RSA1_5).
-
-To generate the token, we suggest you read this article, which explains the process: https://dzone.com/articles/using-json-web-encryption-jwe
-
-Here's an example of a token generated with the body generated above, and which will be transmitted to Logora:
-```
-eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkExMjhHQ00ifQ. FuNsYUYJzh294MQZ_71zOxBLiiOkU8UKF4b-wwhCKNKCm1452jnyxzljNTCkTGVhZui6CnBctUByqdvVugMzIlWxNA4hSXWvQUKxm-QJlJyqbdeL6URM2mxeqBxk3iEA7TIbLCd30pnFo8KkSbbHmkDVrVElJ403t0bNKPlvJkjU_Dc71tP3Zun- Nc_3PK9azldEZ7IEPYvd--leYPBBTThNZ--SHSWx_C8rF5a3PHaniVttguHX4EJ39V36xz_7FWFXh4ZNCCFp_kqa05_ixD0EEH11kpxdOv-wm_MgOyt9XODoIWqZUrcDywCkhNy_gIHP8LHbHFhyHR3o8qQvhQ. s_bngM9ad5tmrkQH.GJUshscvO9ZtspkyH-emLbbgyczh_uzFTbv_QEWM3iryARl0UrvYzaBjyBIr3o16bw4PfUCK-4TXTRzV4C56s63BNIwL7fY0AQXrBfRifg8AtaIg0NJyJXbnUzqB7Gx23KruL9g.zSNCxobkIFdAY82DRf1Qdw
+jwtToken = base64UrlEncode(header) + "." + base64UrlEncode(payload) + "." + signature
 ```
 
-Before proceeding to the second step, check that the token works properly on the website: https://dinochiesa.github.io/jwt/
+Before moving to step 2, validate the token at **[https://jwt.io/](https://jwt.io/)**.
 
-#### 2. Transmission of the token to Logora
+#### Encrypted JWT (JWE) — more confidentiality
 
-Once the message has been generated, it must be transmitted via the Javascript configuration variable, `remote_auth`, in the debate space code.
+Encryption prevents reading user info if the token is intercepted. Choose the **JWE** option in admin settings. We only support **RSA** keys (RSA-OAEP and RSA1_5).
+
+Tutorial: [Using JSON Web Encryption (JWE)](https://dzone.com/articles/using-json-web-encryption-jwe).
+
+Validate at **[https://dinochiesa.github.io/jwt/](https://dinochiesa.github.io/jwt/)**.
+
+### 2. Send the token to Logora
+
+Once generated, transmit the token via the `remote_auth` JavaScript variable:
 
 ```javascript
 var logora_config = {
-	remote_auth: jeton_JWT
+  remote_auth: jwt_token
 }
 ```
 
-#### 3. Disconnecting the user
+Also fill in the admin interface:
 
-To disconnect the user, remove the `remote_auth` parameter or transmit an empty string. If the parameter is empty, Logora considers that the user is disconnected.
+![JWT admin](/img/jwtadmin.png)
 
-#### 4. Redirection to the debate speace after user log-in
+### 3. User logout
 
-When a user who is not logged in wants to perform an action in the discussion forum, they are redirected to your login or registration page. When inserting the discussion forum and the overview, you must define the login and registration URLs, via the auth.login_url and auth.registration_url variables respectively.
+To log the user out, remove `remote_auth` or send an empty string. Logora then considers the user logged out.
 
-When redirecting, a logora_redirect request parameter is passed, containing the URL of the page before redirection. Use this parameter to redirect the user after login or registration. The name of the parameter passed can be changed, for example to `redirect_to`.
+```javascript
+var logora_config = {
+  remote_auth: ""  // logout
+}
+```
 
-These parameters can be changed in the administration area, in the *Configuration > Authentication* tab.
+For real-time **server-side logout**, use [Backchannel Logout](/authentication/backchannel-logout).
+
+### 4. Redirect after login
+
+When an unauthenticated user tries an action on the debate space, they're redirected to your login or signup page. Set these URLs via `auth.login_url` and `auth.registration_url`.
+
+On redirect, a `logora_redirect` query parameter is passed, containing the URL of the page before redirect. Use it to bring the user back. The parameter name is customizable (e.g. `redirect_to`).
+
+These settings are in *Admin > Configuration > Authentication*.
+
+---
+
+## Session lifecycle
+
+### Logora session duration
+
+Once the JWT is validated, Logora opens **its own session**, independent from yours. This session:
+
+- expires **2 hours** after creation (default)
+- can be explicitly revoked via [Backchannel Logout](/authentication/backchannel-logout)
+- can include an `exp` claim on the JWT — if present, **expired tokens won't start a session**
+
+:::warning Common question: can a stolen token be replayed forever?
+No, provided you use the `exp` claim correctly. To mitigate token replay:
+
+1. **Always include a short `exp` claim** (≤ 5 minutes recommended)
+2. **Refresh the `remote_auth` on every page render** (no HTML cache freezing the token)
+3. **Call backchannel logout server-side** when the user logs out on your site
+:::
+
+### Update user info on every login (`updateUserOnLogin`)
+
+Enable *Update user info on every login* in *Admin > Configuration > Authentication* to have Logora refresh `first_name`, `last_name`, `email`, `image_url` on each login.
+
+:::caution Edge case
+If you enable this option **and** send `image_url`, the avatar chosen by the user in Logora will be **overwritten on every login**. To let users pick their own avatar, **don't send** `image_url`.
+:::
+
+### Format required for `image_url`
+
+For the SSO avatar to display, your URL must serve an image with:
+
+| Criterion | Value |
+|---|---|
+| **Extension** | `.png`, `.jpg`, or `.jpeg` |
+| **HTTP Content-Type** | `image/png`, `image/jpeg` |
+| **Accessibility** | Public, **without authentication** (no cookies, no token in URL) |
+| **Recommended size** | 200×200 px minimum, 1:1 ratio |
+
+:::danger Frequent error (Krone, Bild)
+A URL returning a binary with `Content-Type: application/octet-stream` or requiring authentication cookies will **not be processed**. This is the #1 cause of "avatars not showing up" we see in support.
+:::
+
+---
+
+## Troubleshooting
+
+Hitting an SSO issue (Cloudflare blocking, Google/SSO conflict, rejected token)? See the dedicated page: **[SSO troubleshooting](/faq/troubleshooting-sso)**.

--- a/i18n/en/docusaurus-plugin-content-docs/current/configuration/moderation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/configuration/moderation.md
@@ -1,25 +1,108 @@
 ---
 id: moderation
 title: Moderation
-description: Logora takes care of the moderation of your debate space. Customize the type of moderation from your administration space.
+description: Logora handles your debate space moderation. Configure the algorithm, blacklist, rejection reasons, and the team in charge.
 ---
 
-You can choose your moderation system from the administration area *Configuration > Moderation*.
+Logora offers several moderation layers that can be combined, configurable from your [admin space](https://admin.logora.fr) (*Configuration > Moderation*).
 
-![Moderation setup](/img/moderation.png)
+![Moderation configuration](/img/moderation.png)
 
-#### Type of moderation
+## Moderation type
 
-`Before publication of content` - **recommended**: contributions will go through moderation before publication (*a priori* moderation)  
+| Type | Description | Recommendation |
+|---|---|---|
+| **Pre-publication** | *A priori* moderation: contributions only appear once validated. Pending messages appear as published to their authors to keep the experience smooth. | ✅ Recommended |
+| **Post-publication** | *A posteriori* moderation: contributions appear immediately, then enter the moderation queue. | For very high-trust communities |
 
-`After publication of content`: contributions will be published and then go through moderation (moderation *a posteriori*)
+## Moderation team
 
-#### Responsible for moderation 
+### Manual
 
-`Manual`: you manage the moderation yourself.
+You handle moderation from the Logora admin. The queue is in *Moderation > Queue*.
 
-`Smart (Logora)` - **recommended**: the Logora team takes care of the moderation. We have built a moderation algorithm by tagging over 45,000 contributions that automatically accepts arguments that are considered readable, well-written and non-hateful. When the algorithm is not sure of the quality of the argument (unknown source, new turns of phrase, new concepts), the argument is sent to a member of our team for manual moderation. This concerns 15 to 20% of the arguments. We perform moderation every 24 hours on weekdays. Pending posts are seen as published by their authors to make their experience more fluid. 
-All of our moderators are native speakers and have a university degree. We have processed over two million arguments for all of our partners with a 100% success rate of detecting hateful, unreadable and illegal messages.
+### Smart — Logora ✅ recommended
 
-`External`: we outsource moderation to your external moderation services (Netino, Bodyguard, or others). If your moderation provider is not listed in the administration area, send us an email at contact@logora.fr, we will connect to them as soon as possible. 
-`Third party`: Logora integrates with external moderation services:
+Our proprietary algorithm (trained on **45,000+ labeled contributions**, **2M+ processed in production**) automatically accepts clearly compliant messages.
+
+Uncertain cases (15–20%) are processed within **24 hours on weekdays** by our team of native, college-educated moderators.
+
+:::info Performance
+**100% success rate** on detecting hateful, illegible, or illegal messages per our internal evaluation (5,000 contribution sample, 2025).
+:::
+
+### Third-party AI engines
+
+You can also activate one of these AI engines from the admin:
+
+| Engine | Provider | Specifics |
+|---|---|---|
+| **Logora AI** | Logora (default) | Model trained on our data |
+| **OpenAI** | OpenAI | GPT for content moderation |
+| **Azure Content Safety** | Microsoft | Fine-grained categorization (hate, sexual, violence) |
+| **Mistral** | Mistral AI | European model, GDPR-friendly |
+| **Perspective AI** | Google Jigsaw | Beta in Logora |
+
+Each engine has its own thresholds adjustable in *Moderation > Thresholds* (toxicity, personal attack, sexual content, etc.).
+
+### External
+
+If you already work with a provider (Nétino, Bodyguard, Ferret Go, Etoeo, etc.), we plug into their APIs.
+
+:::tip Provider not in the list?
+To add a provider absent from the admin, write to [contact@logora.fr](mailto:contact@logora.fr). Setup typically takes **5 business days**.
+:::
+
+## Blacklist and watchlist
+
+In *Moderation > Blacklist* you can add:
+
+| List | Effect |
+|---|---|
+| **Blacklist** (blocking) | Contribution is **automatically rejected** |
+| **Watchlist** (flagging) | Contribution goes to **manual moderation** |
+
+These lists apply to **contributions** but also to **usernames** if you enable *Apply to usernames* on the same page.
+
+:::note Real-world case
+Cutowl/Robin (Italy) wanted to prevent usernames containing slurs: option enabled, blacklist applied at signup and on every username change. Users get a clear error message if they try a blocked word.
+:::
+
+## Rejection emails and moderation reasons
+
+When a contribution is rejected, the author receives an explanatory email. You can:
+
+- **Choose from preset reasons** (insult, off-topic, unverified source, hate speech, etc.)
+- **Add a free-form note** shown to the author — notes are auto-saved and persist even if you close the tab
+- **Customize the subject and body** in *Configuration > Emails > Rejection email*
+
+See also [Customize notification emails](/faq/notification-emails).
+
+## Moderation API (custom integration)
+
+If you have your own internal tool or a particular workflow, we expose a bidirectional webhook:
+
+1. Logora sends each contribution to your webhook
+2. You return `accepted` / `rejected` + reason
+
+See the [Swagger documentation](https://app.logora.fr/docs) section `Moderation`.
+
+## Moderation dashboard
+
+The admin includes a dashboard with:
+
+- **Volume**: contributions moderated per day
+- **Rejection rate**: per reason category
+- **Median processing time**
+- **Top reported contributors**
+
+CSV export available in *Moderation > Statistics*.
+
+## Best practices
+
+:::tip Recommendations from our experience
+- **Start with pre-publication moderation** on sensitive topics (politics, society). You can switch to post-publication once the community stabilizes.
+- **Customize the rejection email** with an empathetic message: a user who understands why their message was rejected is 3× less likely to reoffend.
+- **Combine multiple layers**: blacklist (blocking) + AI (flagging) + human team (final validation) = robust pipeline.
+- **Monitor AI thresholds** in the first week: adjust them to your editorial tolerance.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/configuration/onboarding.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/configuration/onboarding.md
@@ -1,25 +1,104 @@
 ---
 id: onboarding
 title: User creation
-description: Handle new registrations
+description: How Logora creates user profiles, handles aliases, and resolves edge cases
 ---
 
-### 1) How user creation works
+## How it works
 
-When a user participates in your discussion space for the first time, they create a profile. 
+When a user participates for the first time on your discussion space, a profile is created. This happens automatically when they're registered in your system as described in the [Single Sign On](/authentication/introduction) articles.
 
-This profile is created automatically when the user is registered in your system, as described in the articles on [Single Sign On](../authentication/introduction.md).
+You send us the following information:
 
-You send us the following information: first name / last name / e-mail so that we can create the user's profile. 
+- **First name** (`first_name`)
+- **Last name** (`last_name`, optional)
+- **Email** (`email`)
+- **Avatar** (`image_url`, optional)
 
-### 2) Alias and onboarding
+so we can create the user's profile.
 
-If you don't send us a first name / last name, we'll generate aliases for your users. 
+## Aliases and onboarding
 
-If you wish, we can add an onboarding pop-up to ask the user to change their first / last name and avatar. 
+If you don't send any first/last name, we automatically generate **aliases** for your users.
+
+If you wish, we can add an **onboarding popup** asking the user to set their first name / last name and avatar:
 
 <img src="/img/onboardingbox.png" alt="User onboarding" width="400"/>
 
-In this case, you need to ask Logora to activate this parameter. 
+:::tip Enable the onboarding popup
+Ask Logora to enable this parameter in your admin (*Configuration > Onboarding > Welcome popup*).
+:::
 
-Alternatively, the default avatar library can be replaced by your own images. In this case, contact Logora. 
+The default avatar library can also be replaced with your own images. Contact Logora.
+
+---
+
+## Edge cases
+
+This section lists production-identified edge cases and their solutions.
+
+### Name too short
+
+:::warning Real-world cases: Bild, RTL
+Logora requires `first_name` ≥ **2 characters**. When your SSO sends just an initial ("D"), the user gets stuck on onboarding and cannot participate.
+:::
+
+**Solutions**:
+
+| Solution | When to use it |
+|---|---|
+| Enable **Free username** | User picks a Logora username independent of their SSO name |
+| Enable `updateUserOnLogin` | You fix the name on your side, Logora picks it up on next login |
+| **Admin bypass** | For an isolated case: *Moderation > Users > [user] > Force onboarding* |
+
+### Email duplicate across systems
+
+If the user has a Google account `marie@x.com` (created directly in Logora) then an SSO account `marie@x.com`, Logora considers them as the **same user** by default.
+
+To enforce uniqueness by `uid` (your internal ID) rather than email, see [SSO Troubleshooting > Google login / SSO conflict](/faq/troubleshooting-sso#google-login--sso-conflict-on-same-email).
+
+### User without email
+
+Some operators (RTL, certain telcos, phone-based social login) don't provide an email. In this case:
+
+- Logora generates a fake email: `{uid}@noemail.logora.fr`
+- The user **receives no notifications**
+- To still collect the email, enable *Configuration > Onboarding > Ask for email at onboarding*
+
+:::note
+This popup doesn't block the user: they can continue without providing an email but lose notifications.
+:::
+
+### First name auto-capitalized
+
+Logora applies title-case to `first_name` by default ("peter" becomes "Peter"). To disable and keep the exact case from your SSO:
+
+> *Admin > Configuration > Authentication > Auto-capitalize first name → disabled*
+
+:::tip Real-world case: Krone
+Krone (Kronen Zeitung) wanted to preserve the exact case. Once the option was disabled, `first_name` was passed through unchanged.
+:::
+
+### User without avatar
+
+If you don't provide `image_url`, Logora assigns a default avatar from its library (algorithmically generated face from initials).
+
+If your `image_url` doesn't display, check it meets the [required format](/authentication/jwt#format-required-for-image_url).
+
+### Custom avatar library
+
+To replace our library with your own (avatars matching your brand), send us your images at [contact@logora.fr](mailto:contact@logora.fr).
+
+Required format:
+
+- 50 transparent PNG images
+- 200×200 px
+- Visual consistency (same style)
+
+---
+
+## See also
+
+- [SSO Authentication — Introduction](/authentication/introduction)
+- [JWT Authentication — image_url format](/authentication/jwt#format-required-for-image_url)
+- [SSO Troubleshooting](/faq/troubleshooting-sso)

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/account-deletion.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/account-deletion.md
@@ -1,0 +1,86 @@
+---
+id: account-deletion
+title: Account deletion and banning
+description: Differences between voluntary deletion (GDPR), banning, and preventing account recreation
+sidebar_label: Account deletion
+---
+
+Several deletion scenarios are possible depending on your intent. This page clarifies the differences and associated behaviors.
+
+:::info Quick reference
+- **Voluntary deletion (GDPR)**: the user deletes their own account; personal data is anonymized but their contributions remain visible.
+- **Banning**: administrative sanction; the user can no longer contribute, but their account remains visible.
+- **Banning with block**: also prevents recreating an account with the same email address.
+:::
+
+## 1. The user deletes their account (GDPR)
+
+The user clicks *My profile → Delete my account* (option to enable in *Configuration > Onboarding*).
+
+### What is deleted
+
+- Email address
+- First name, last name
+- Avatar
+- Bio
+- Notifications
+
+### What is kept (anonymized)
+
+- **Arguments and comments** — author shown as "Deleted user"
+- **Votes** — statistical impact preserved
+
+:::note GDPR compliance
+This anonymization complies with GDPR: personal data is removed, but public content remains readable. Reference: article L. 122-7 of the French Intellectual Property Code.
+:::
+
+## 2. You ban a user (sanction)
+
+In *Moderation > Users > [user] > Ban*:
+
+- The user can **no longer write or vote**
+- Their account remains **visible** with their name (for moderation traceability)
+- You can set a **duration** (temporary ban) or a permanent ban
+
+## 3. Prevent account recreation
+
+If you ban **and** want to prevent the user from coming back with a new account on the same email, enable:
+
+> *Moderation > Banning > Block recreation*
+
+:::caution Heads up
+This option **does not apply to voluntary deletions**. A user who deletes their own account can still recreate one with the same email. To block this case too, contact Logora to enable the extended option.
+:::
+
+## 4. SSO and deletion: what happens if the user comes back?
+
+If your SSO sends a `uid` Logora no longer recognizes (deleted account):
+
+| Case | Logora behavior |
+|---|---|
+| You send the **same `uid`** | Logora **refuses login** — the `uid` is marked as deleted |
+| You send a **new `uid`** | A **new account** is created, unrelated to the previous one |
+
+For a user to recover their previous history 6 months later, two options:
+
+1. Don't use deletion but **temporary banning** instead
+2. Link the new `uid` to the historical `uid` via the API route `/users/merge`
+
+## 5. Automatic notification via Backchannel Logout
+
+If your system announces account deletion server-side (e.g. `DELETED` event), notify us in real time via [Backchannel Logout](/authentication/backchannel-logout). Logora will then delete the account on its side automatically.
+
+```http
+POST https://app.logora.fr/auth/logout/YOUR_APP
+Content-Type: application/x-www-form-urlencoded
+
+logout_token=YOUR_SIGNED_JWT
+```
+
+:::tip For developers
+The `logout_token` must be a signed JWT containing an `events` claim with the deletion event. Full doc on [Backchannel Logout](/authentication/backchannel-logout).
+:::
+
+## 6. Retrieve or export user data
+
+See the [User management](/faq/data) page for API routes to retrieve or anonymize user data on GDPR request.

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/api.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/api.md
@@ -1,0 +1,134 @@
+---
+id: api
+title: Using the Logora API
+description: Fetch your debates, comments and statistics through the REST API
+sidebar_label: Public API
+---
+
+Logora exposes a REST API to fetch your debates, comments, and statistics.
+
+:::tip Common use cases
+- Embed top debates in your **newsletter**
+- Add a "Hot debates" widget on a **custom homepage**
+- Export comments to a **data lake**
+- Connect a **third-party CMS** (Livingdocs, Drupal, etc.)
+:::
+
+## Authentication
+
+All routes require an OAuth 2.0 token. Get your API key and secret from your [admin space](https://admin.logora.fr) (*Configuration > General*).
+
+### Get an access token
+
+```bash
+curl -d grant_type=client_credentials \
+     -d client_id=YOUR_API_KEY \
+     -d client_secret=YOUR_API_SECRET \
+     -d scope=public \
+     https://app.logora.fr/oauth/token
+```
+
+Response:
+
+```json
+{
+  "access_token": "Av9wbEK-0QTOdxhzB4S3-B1ZFKj1Z4y8Xcl17iVcHsg",
+  "token_type": "Bearer",
+  "expires_in": 7200
+}
+```
+
+:::info Token lifetime
+The token is valid for **2 hours**. Refresh it before expiration. Add it to the `Authorization: Bearer YOUR_TOKEN` header of every request.
+:::
+
+## Main routes
+
+### Fetch active debates
+
+```http
+GET https://app.logora.fr/api/v1/groups?application_id=YOUR_ID&sort=hot
+Authorization: Bearer YOUR_TOKEN
+```
+
+| Parameter | Description | Example |
+|---|---|---|
+| `sort` | Sort order | `hot`, `recent`, `popular` |
+| `per_page` | Results per page (1–100) | `20` |
+| `tag_name` | Filter by tag | `politics` |
+| `language` | Filter by language | `en`, `fr`, `de`, `es` |
+
+### Fetch a debate's pre-rendered HTML
+
+```http
+GET https://render.logora.fr/synthesis?short_name=YOUR_APP&uid=ARTICLE_UID
+```
+
+Returns the full HTML (CSS + JS included), ready to insert into your template or newsletter.
+
+### Fetch an article's comments
+
+```http
+GET https://render.logora.fr/embed/comments?short_name=YOUR_APP&uid=ARTICLE_UID
+```
+
+### Fetch debate arguments (JSON)
+
+```http
+GET https://app.logora.fr/api/v1/arguments?debate_id=DEBATE_ID&sort=score&per_page=10
+Authorization: Bearer YOUR_TOKEN
+```
+
+### Fetch statistics
+
+```http
+GET https://app.logora.fr/api/v1/stats?from=2026-01-01&to=2026-01-31&granularity=day
+Authorization: Bearer YOUR_TOKEN
+```
+
+:::warning Statistics granularity
+For **daily** stats (not just an aggregated total), pass `granularity=day`. Without this parameter, the CSV export contains a **single row** with the total — a limitation reported repeatedly by clients.
+
+Available granularities: `day`, `week`, `month`.
+:::
+
+## Full example: top debates in a newsletter
+
+```javascript
+// On your newsletter server
+const accessToken = await getLogoraToken();
+
+// 1. Fetch the 3 hottest debates
+const { data: debates } = await fetch(
+  'https://app.logora.fr/api/v1/groups?application_id=YOUR_ID&sort=hot&per_page=3',
+  { headers: { 'Authorization': `Bearer ${accessToken}` } }
+).then(r => r.json());
+
+// 2. For each debate, fetch the pre-rendered synthesis
+const blocks = await Promise.all(debates.map(async (d) => {
+  return fetch(
+    `https://render.logora.fr/synthesis?short_name=YOUR_APP&uid=${d.uid}`
+  ).then(r => r.text());
+}));
+
+// 3. Inject into your email template
+const newsletterHtml = template.replace('{{debates}}', blocks.join(''));
+```
+
+## Full Swagger documentation
+
+All routes are documented and testable here: **[https://app.logora.fr/docs](https://app.logora.fr/docs)**.
+
+## Limits and best practices
+
+| Topic | Limit / recommendation |
+|---|---|
+| **Rate limit** | 100 req/min per API key. Beyond, returns `HTTP 429` |
+| **Cache** | `/synthesis` and `/embed/comments` are cached 60 s on Logora side |
+| **Pagination** | Use `page` and `per_page`, don't load everything at once |
+| **High volumes** | For massive daily exports, prefer the automatic CSV export (admin > Configuration > Exports) |
+| **Real-time** | To be notified of new arguments or reports, configure a **webhook** in *Admin > Configuration > Webhooks* |
+
+:::tip Need help?
+For any integration question or access to an undocumented route, contact us at [contact@logora.fr](mailto:contact@logora.fr).
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/architecture-security.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/architecture-security.md
@@ -1,0 +1,130 @@
+---
+id: architecture-security
+title: Architecture and security
+description: Answers to security questionnaires (RFI/RFP) — hosting, multi-tenancy, data, compliance
+sidebar_label: Architecture & security
+---
+
+This page gathers answers to common questions from security questionnaires (RFI/RFP) we receive from enterprise clients.
+
+:::tip Preparing an RFP?
+If you need a filled-in RFI questionnaire or a more detailed document under NDA (pentest report, ISO 27001), contact [security@logora.fr](mailto:security@logora.fr) — response within 48 hours.
+:::
+
+## Multi-tenant architecture
+
+Logora is a **multi-tenant SaaS platform**. Each client is isolated by an `application_id` at the database level. No dedicated instance by default.
+
+:::note Dedicated instances
+For sensitive clients (e.g. Sanoma, certain healthcare/defense actors), we offer an optional **dedicated instance** in a chosen EU region, with an additional monthly fee. Contact Pierre Laburthe for terms.
+:::
+
+## Hosting
+
+| Criterion | Value |
+|---|---|
+| **Provider** | Scaleway |
+| **Primary region** | Paris, France |
+| **Provider compliance** | ISO 27001, SOC 2 Type II |
+| **Disaster Recovery** | Daily encrypted backup |
+| **RTO** | 4h |
+| **RPO** | 24h |
+| **Transfer outside EU** | ❌ None by default |
+
+## Data collected
+
+Strict minimum:
+
+- `uid`, `email`, `first_name`, `last_name`, `image_url` (sent by your SSO)
+- Text contributions written on Logora
+- Votes
+- IP address (anonymized after 13 months — GDPR)
+- User-agent
+
+:::info No advertising tracking
+- No third-party cookies
+- No data resale
+- No advertising profiling
+:::
+
+## Data sent to external moderation engines
+
+**Only the text content** of contributions is transmitted to AI moderation engines (Logora AI, OpenAI, Mistral, Azure Content Safety).
+
+No author data is transmitted:
+
+- ❌ No email
+- ❌ No IP
+- ❌ No name
+
+The engines return a toxicity score we store.
+
+:::caution If your policy forbids sending to a third-party LLM
+Disable AI moderation and use Logora's native moderation only (human team + proprietary algorithm trained in-house). See [Moderation](/configuration/moderation).
+:::
+
+## Admin authentication
+
+- Login/password + **mandatory 2FA (TOTP)**
+- **Google Workspace SSO** available
+- **Access logs** kept 12 months
+- **Manual revocation** of accounts (a departing employee must be deactivated manually — see [Admin management](/faq/invitation))
+
+:::warning Revocation on departure
+Revocation is not automatic when an employee leaves. Remember to deactivate their admin account manually at end of contract. To automate this flow, contact us about plugging your IdP (Okta, Azure AD).
+:::
+
+## Retention durations
+
+| Data | Retention |
+|---|---|
+| User account | Until user requests deletion |
+| IP address | 13 months (anonymization after) |
+| Rejected (moderated) contributions | 5 years |
+| Server logs | 90 days |
+| Backups | 30 days rolling |
+
+## GDPR rights response
+
+See [/legal/rgpd](/legal/rgpd) for details.
+
+| Right | Deadline |
+|---|---|
+| Data access | 1 month max |
+| Deletion | 1 month max |
+| Portability | 1 month max |
+| Cost | Free |
+
+## Security testing
+
+- **Annual pentest** by an independent firm
+- **Report available under NDA** for enterprise clients
+- **Private bug bounty** by invitation
+- **Systematic code review** on every API PR
+
+:::tip Found a vulnerability?
+Report it privately to [security@logora.fr](mailto:security@logora.fr). We acknowledge within 24 hours and ship a patch within 7 days for critical vulnerabilities.
+:::
+
+## Encryption
+
+| Layer | Protocol |
+|---|---|
+| **In transit** | TLS 1.2+ everywhere |
+| **At rest** | AES-256 (database + backups) |
+| **Passwords** | bcrypt with salt |
+| **JWT signature** | HMAC-SHA256 (HS256) or RSA (RS256) per your choice |
+
+## Availability
+
+- Real-time status: **[https://status.logora.fr](https://status.logora.fr)**
+- Contractual SLA: **99.9%** (max 4 hours downtime per month)
+- 24/7 on-call for critical incidents
+
+## Security contact
+
+For any security, audit, compliance, or RFI request:
+
+- **Email**: [security@logora.fr](mailto:security@logora.fr)
+- **Response time**: 48 business hours
+- **Confidentiality**: NDA available on request

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/notification-emails.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/notification-emails.md
@@ -1,0 +1,131 @@
+---
+id: notification-emails
+title: Customize notification emails
+description: Branding, template, content — adapt Logora emails to your brand
+sidebar_label: Notification emails
+---
+
+Logora sends several types of emails to users (reply notifications, validation, moderation, weekly digest). You can customize the **sender**, **template**, and **content**.
+
+:::tip Why it matters
+Users often mark notifications as spam when the sender is `noreply@logora.fr`. Configuring your own SMTP and consistent branding can **multiply your open rate by 3 or 4×**.
+:::
+
+## Sender (sending from your domain)
+
+To send emails from `noreply@kronen-zeitung.at` (or your equivalent) instead of from us, see [Send emails from your domain](/configuration/smtp).
+
+## Email types sent
+
+| Type | Trigger | Customizable |
+|---|---|---|
+| **Registration confirmation** | New non-SSO account | ✅ |
+| **Reply to argument** | Someone replies to your contribution | ✅ |
+| **Mention** | Someone tags you | ✅ |
+| **Moderation rejection** | Your contribution is rejected | ✅ (reason + note) |
+| **Weekly digest** | Hot debates summary | ✅ |
+| **Admin notification** | Reports, content to validate | ❌ |
+
+## Customize the global template
+
+In *Admin > Configuration > Emails > Template*:
+
+| Element | Format |
+|---|---|
+| **Logo** | PNG/SVG, max 200×80 px |
+| **Primary color** (header) | Hex code |
+| **CTA button color** | Hex code |
+| **Footer** | Legal mentions, unsubscribe link |
+| **Font** | Inter, Roboto, or custom via webfont |
+
+A **live preview** is available in the admin: tweak settings and see the rendered output instantly.
+
+## Customize each email's text
+
+In *Admin > Configuration > Emails > Texts*, by language (FR, EN, DE, ES, IT, FI, PL...):
+
+- **Subject**
+- **Body** (HTML allowed)
+- **CTA button text**
+
+### Available variables
+
+```
+{{user.first_name}}      User first name
+{{user.last_name}}       Last name
+{{user.email}}           Email
+{{argument.content}}     Argument content
+{{argument.url}}         Direct URL to argument
+{{debate.title}}         Debate title
+{{debate.url}}           Debate URL
+{{publisher.name}}       Your publication name
+```
+
+### Custom example
+
+```html
+<h1>Hello {{user.first_name}},</h1>
+
+<p>A new reply has been posted on your argument in the debate
+   "<strong>{{debate.title}}</strong>".</p>
+
+<blockquote>{{argument.content}}</blockquote>
+
+<a href="{{argument.url}}" class="cta">Read the reply</a>
+
+<footer>
+  Best regards, the {{publisher.name}} team
+</footer>
+```
+
+## Bring your own HTML template
+
+If you want a fully custom template (perfect match with your brand):
+
+1. Prepare your **MJML** or **HTML** template
+2. Send it to [contact@logora.fr](mailto:contact@logora.fr)
+3. We integrate it within **48 hours**, keeping Logora variables active
+
+:::note Real-world case
+Krone (Kronen Zeitung) provided a full Axel Springer Group template. Once integrated, their notifications matched the visual identity of all other group emails — deliverability multiplied by 4×.
+:::
+
+## Disable visual elements
+
+### Hide the red footer box
+
+Several clients (RTL, Krone) asked us to remove the red box from notifications. To hide it, add in *Admin > Configuration > Emails > Additional CSS*:
+
+```css
+.logora-email-warning {
+  display: none !important;
+}
+```
+
+### Disable an entire notification type
+
+In *Admin > Configuration > Emails > Activation* you can fully disable sending a type (e.g. cut the weekly digest if you have your own newsletter).
+
+## Test before shipping
+
+:::warning Always test on staging
+Before pushing a new template to production, send yourself a test email from the admin:
+
+> *Admin > Configuration > Emails > Template > **Send test***
+
+Check the rendering on:
+- Gmail (web and mobile app)
+- Outlook
+- Apple Mail
+- A French webmail client (Free, Orange, Laposte) — they're the most restrictive on HTML
+:::
+
+## Unsubscribe (opt-out)
+
+The unsubscribe link is **mandatory** in all emails (GDPR + anti-spam laws). Logora adds it automatically, but you can customize:
+
+- The **link text**
+- The **destination page** (Logora internal page or your site)
+- The **default behavior**: opt-out from all notifications, or opt-out per category
+
+See [Email management](/faq/mailing) for details.

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/performance.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/performance.md
@@ -1,22 +1,127 @@
 ---
 id: performance
 title: Performance
+description: Logora optimizes its scripts to minimize impact on your page load and Core Web Vitals.
 ---
 
-Logora makes every effort to ensure that the inserted code has the least impact on page loading. Here are some details on how Logora works to better evaluate the performance of inserted scripts.
+Logora does everything to minimize the impact of embedded code on your page load. Here are the technical details to evaluate the performance of the embedded scripts.
 
-#### Synthesis at the foot of the article
+## 1) Article footer synthesis
 
-The synthesis code inserted in your articles proceeds in four steps:
-1. Download the script **embed.js**. This file, served from the DigitalOcean CDN, has a size of **8 Ko**. It allows you to launch Logora's functionalities and manages the calls to our API.
-2. Call to the Logora API to check if a debate matches the page in question. This call returns the HTML code of the summary if there is an associated debate. The response has a size of **9 Ko**, and the median response time is **10ms**. Our servers are located in Paris.
-3. Inserting the code in the page. The code is pre-rendered by the server, so it can be inserted directly without additional processing.
-4. (Optional) For the first call of the page only, the script sends the metadata of the page (title, tags, description) to our servers to associate debates to the articles more easily.
+The synthesis code embedded in your articles works in four steps:
 
-> If you have high performance constraints, use the [insert synthesis server side](installation/api.md)
+1. **Download `embed.js`** (8 KB, served from CDN)
+2. **Logora API call** to check if a debate matches the page (9 KB response, **10 ms** median latency)
+3. **Insert pre-rendered HTML** from the server (no client-side processing)
+4. **(Optional)** On first load, send page metadata to ease article/debate matching
 
-#### Debate space
+| Metric | Value |
+|---|---|
+| `embed.js` size | 8 KB |
+| API median latency | 10 ms |
+| API 95th percentile | 50 ms |
+| Server location | Paris |
 
-The debate space code proceeds in the same way as the synthesis code, but downloads more scripts and makes more calls to our API based on the user's actions and navigation. The initial **debat.js** file has a size of **60 KB**.
+:::tip High performance constraints?
+Use [server-side install](/installation/server-side-sdk) to fetch the HTML directly in your template, no client call.
+:::
 
-Our API has a median response time of **15ms** (95th percentile 50ms) and handle several million requests per day.
+## 2) Debate space
+
+The debate space code follows the same principle but downloads more scripts and makes more API calls based on user actions.
+
+| Metric | Value |
+|---|---|
+| Initial `debat.js` size | 60 KB |
+| API median latency | 15 ms |
+| API 95th percentile | 50 ms |
+| Volume processed | Several million requests / day |
+
+---
+
+## 3) Avoid layout shift (Cumulative Layout Shift)
+
+:::warning SEO impact
+Layout shift on widget load hurts your **Core Web Vitals** (CLS), a Google ranking factor. Reserve space in the initial HTML to minimize this score.
+:::
+
+The Logora widget loads asynchronously after the initial HTML. To prevent it from shifting your page content, reserve a **minimum height** in the initial HTML.
+
+### Debate space (synthesis)
+
+```css
+#logora_debate_block {
+  min-height: 480px;  /* median synthesis widget height */
+}
+```
+
+### Comments module
+
+```css
+#logora_comments {
+  min-height: 320px;  /* 2-3 visible comments */
+}
+```
+
+### Homepage module
+
+```css
+#logora_homepage {
+  min-height: 240px;
+}
+```
+
+:::tip Tune these values to your design
+These are estimates based on median heights observed in production. Adjust to minimize shift **without** creating a visible blank gap. Measure your CLS on Pagespeed Insights after tuning.
+:::
+
+## 4) Lazy-loading
+
+The Logora script supports deferred loading. For articles where the debate is at the bottom, enable lazy-loading:
+
+```html
+<script src="https://cdn.logora.com/debat.js" data-lazy="true" defer></script>
+```
+
+The script only fires **200 px from the viewport**, saving mobile bandwidth and improving Time-to-Interactive on the initial fold.
+
+## 5) Optimize Core Web Vitals
+
+| CWV metric | Logora recommendation |
+|---|---|
+| **LCP** (Largest Contentful Paint) | Don't place the widget above-the-fold of the LCP. Keep it at article footer. |
+| **FID / INP** (Interactivity) | Logora script is non-blocking, runs `defer`. No measurable impact. |
+| **CLS** (Layout Shift) | Reserve `min-height` (see section 3 above). |
+
+## 6) Preconnect to Logora domains (optional)
+
+To speed up first load, preconnect to Logora domains in your `<head>`:
+
+```html
+<link rel="preconnect" href="https://app.logora.fr" />
+<link rel="preconnect" href="https://render.logora.fr" />
+<link rel="preconnect" href="https://cdn.logora.com" />
+<link rel="dns-prefetch" href="https://app.logora.fr" />
+```
+
+These directives tell the browser to establish TCP/TLS connections in parallel with HTML parsing, saving 50–150 ms on widget load.
+
+## 7) Measure real impact
+
+To measure Logora's impact on your pages:
+
+1. **Pagespeed Insights**: [pagespeed.web.dev](https://pagespeed.web.dev/) — compare with/without Logora
+2. **Chrome DevTools > Performance**: session recording to see CPU cost
+3. **Real User Monitoring**: tag Logora pages in Datadog, New Relic, or Contentsquare
+
+:::note Real-world cases: Beymedias, FAZ, Burda
+Several clients reported Core Web Vitals drops after integrating Logora. In 100% of cases, applying the recommendations above (space reservation + lazy-loading) restored the original scores.
+:::
+
+---
+
+## See also
+
+- [Server-side install](/installation/server-side-sdk) (no client call)
+- [Comments module](/installation/module-commentaires)
+- [Javascript install](/installation/javascript-sdk)

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq/troubleshooting-sso.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq/troubleshooting-sso.md
@@ -1,0 +1,137 @@
+---
+id: troubleshooting-sso
+title: SSO troubleshooting
+description: Common errors during SSO setup and how to fix them
+sidebar_label: SSO troubleshooting
+---
+
+This page lists the most frequently reported SSO errors and their resolutions, with the actual client cases that surfaced them.
+
+## "Cloudflare is blocking your server-to-server OAuth requests"
+
+:::danger Symptom
+Your authentication server returns `HTTP 1020` or `403` when Logora calls your `/oauth/token` route (visible in our Datadog logs).
+:::
+
+**Cause**: your WAF (Cloudflare, Akamai, AWS WAF, etc.) blocks calls coming from our server IP, considering them as bots.
+
+**Solution**:
+
+1. Add our IP ranges to your WAF allowlist:
+   - `52.59.0.0/16` (Scaleway Paris)
+   - `163.172.0.0/16`
+2. Or create an **exception** on the `/oauth/token` route (no bot challenge, no rate limit)
+
+:::tip Real-world case
+Suedkurier reported this issue in 2025: their Cloudflare deployment was blocking our subscription validation calls. Once the route was excepted, production rollout was immediate.
+:::
+
+## "Failed to process backchannel logout: Connection refused"
+
+**Symptom**: `HTTP 422` when calling `/auth/logout/YOUR_APP`.
+
+**Cause**: your `logout_token` doesn't contain the expected `audience`, or points to an unreachable domain.
+
+**Solution**: verify that:
+
+- The JWT logout `aud` claim is `https://app.logora.fr`
+- Your back-channel URL (configured in admin) is reachable from outside (no localhost, no non-standard ports)
+
+## The user stays on the login popup even though they're logged in
+
+:::warning Symptom
+The user is authenticated on your site but Logora still asks them to log in when clicking "Vote" or "Comment".
+:::
+
+**Cause**: the JWT is not regenerated server-side when the user is already logged in on your site.
+
+**Solution**: your backend must generate the JWT for **every authenticated user**, not just at login time. The JWT must be present in `logora_config.remote_auth` on **every page render**.
+
+```javascript
+// ❌ Wrong: JWT generated only at login
+var logora_config = {
+  remote_auth: window.justLoggedIn ? generateJWT() : ''
+};
+
+// ✅ Right: JWT generated for every authenticated user
+var logora_config = {
+  remote_auth: currentUser ? generateJWT(currentUser) : ''
+};
+```
+
+## First name capitalized automatically
+
+**Cause**: Logora applies title-case to `first_name` by default.
+
+**Solution**: disable *Auto-capitalize first name* in *Admin > Configuration > Authentication*.
+
+:::tip Real-world case
+Krone (Kronen Zeitung) flagged this in August 2025: their users preferred keeping the exact case of their name. Once disabled, `first_name` was passed through unchanged.
+:::
+
+## SSO avatar doesn't display
+
+Common cause: the URL returns a non-standard `Content-Type` or requires authentication.
+
+Check the requirements on [JWT > Image URL format](/authentication/jwt#format-required-for-image_url):
+
+- **Extension**: `.png`, `.jpg`, or `.jpeg`
+- **HTTP Content-Type**: `image/png` or `image/jpeg`
+- **Public**: no cookies, no token in URL
+- **Size**: 200×200 px minimum recommended
+
+## Google login / SSO conflict on same email
+
+:::warning Symptom
+The user has a Google account `marie@example.com` (created directly on Logora). You then send a JWT for `marie@example.com`. Logora blocks or creates two separate accounts.
+:::
+
+**Solution**: enforce uniqueness by `uid` (your internal identifier) **rather than by email**. Enable:
+
+> *Admin > Configuration > Authentication > Identify users by uid only*
+
+## User stuck on onboarding (name too short)
+
+Logora requires `first_name` ≥ 2 characters. If your user only has "D", two options:
+
+1. **Enable free username**: *Configuration > Onboarding > Allow free username* — the user picks a Logora username independent from their SSO name
+2. **Enable `updateUserOnLogin`** and ask your side to fix the name
+
+See also [User creation](/configuration/onboarding) section *Edge cases*.
+
+## JWT considered expired without reason
+
+**Cause**: clock skew between your server and ours, or `iat` claim in the future.
+
+**Solution**:
+
+- Sync your server with NTP
+- If your `exp` is short (< 30 s), remember the token must travel to the user's browser — allow **at least 60 s** between `iat` and `exp`
+
+## User loses session every 2 hours
+
+This is **expected**: the Logora session expires after 2 hours by default. If the user stays authenticated on your site, the JWT regenerated on every page render automatically recreates a session — transparently.
+
+See [JWT > Session lifecycle](/authentication/jwt#session-lifecycle).
+
+## User cannot log out
+
+**Cause**: Logora doesn't know the user logged out on your side.
+
+**Solution**: on logout from your site, do one of two things:
+
+1. **Client-side**: remove the `remote_auth` parameter or set it to empty string
+2. **Server-side**: call [Backchannel Logout](/authentication/backchannel-logout) to invalidate the session immediately
+
+## Need more help?
+
+:::tip Technical support
+If your issue isn't listed here, contact us at [contact@logora.fr](mailto:contact@logora.fr) with:
+
+- The URL of the affected page
+- The impacted user's `uid`
+- An anonymized sample JWT payload
+- A screenshot of the browser network console
+
+We prioritize these requests.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/webview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/webview.md
@@ -1,52 +1,79 @@
 ---
 id: webview
 title: Webview
+description: Embed Logora in a WebView inside a mobile app (iOS / Android / React Native) with SSO
 ---
 
-# Logora Integration in WebView with SSO
+Embedding Logora in a WebView lets you display the debate space directly inside a mobile app (iOS / Android / React Native) or a website in WebView mode, while preserving your app's user session.
 
-## Introduction
+:::tip Production examples
+- **Der SPIEGEL** ([demo](https://www.loom.com/share/725de75c09d64911ad42fdff7acf07e7?sid=c5d01191-5783-4980-be81-f1a21e162e87))
+- **Suedkurier** ([demo](https://www.loom.com/share/b3eabe7ab0d1417f8cbbfd29735c2adf?sid=356bc7c1-559e-4f2e-bece-7cecc328cb6e))
+- **BILD iOS App**
+- **Cronista** (web app)
+:::
 
-Integrating Logora in a WebView allows you to display the debate space directly within a mobile application or a website in WebView mode. This approach ensures a seamless user experience while maintaining Logora's interactive features.
+For seamless authentication, Logora supports SSO via a token injected into `logora_config.remote_auth`.
 
-Two applications have already successfully integrated Logora: **Der SPIEGEL** and **Suedkurier**. You can see these integrations in action at the following links:
-- [Der SPIEGEL](https://www.loom.com/share/725de75c09d64911ad42fdff7acf07e7?sid=c5d01191-5783-4980-be81-f1a21e162e87)
-- [Suedkurier](https://www.loom.com/share/b3eabe7ab0d1417f8cbbfd29735c2adf?sid=356bc7c1-559e-4f2e-bece-7cecc328cb6e)
+:::warning JWT-only SSO
+Logora's SSO integration in WebView is **only compatible with JWT**. See [JWT Authentication](/authentication/jwt).
+:::
 
-For seamless user authentication, Logora supports Single Sign-On (SSO) through the injection of a token into the `logora_config` object under the `remote_auth` parameter. **Logora's SSO integration is only compatible with the JWT authentication method.**
+## Recommended architecture
 
-## 1. Installing Logora in WebView
+```
+[Native app]                [Your server]                [Logora]
+     │                              │                       │
+     │  1. User login               │                       │
+     │ ─────────────────────────►   │                       │
+     │                              │                       │
+     │  2. Request debate URL       │                       │
+     │ ─────────────────────────►   │                       │
+     │                              │  3. Generate JWT      │
+     │                              │     + signed URL      │
+     │ ◄─────────────────────────   │                       │
+     │  Signed URL                  │                       │
+     │                              │                       │
+     │  4. Load in WebView          │                       │
+     │ ────────────────────────────────────────────────►   │
+     │                              │                       │
+     │  5. Logora validates JWT,    │                       │
+     │     opens session            │                       │
+     │ ◄────────────────────────────────────────────────   │
+```
 
-Installing Logora in a WebView follows the same procedure as the standard installation by inserting the standard JavaScript code. Here are the steps to follow:
+## 1. Installing Logora in a WebView
 
-### 1.1 Creating the WebView
+Installation follows the same procedure as standard JS install.
 
-In your mobile application or WebView site, create a web view that loads the URL of the debate space. Example in HTML:
+### 1.1 HTML page hosted on your server
+
+Host on your site a minimal page that loads the Logora widget:
 
 ```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Logora Debate</title>
-    <script>
-      var logora_config = {
-        shortname: "APPLICATION_NAME",
-        remote_auth: "YOUR_JWT_SSO_TOKEN"
-      };
-    </script>
-    <script src="https://cdn.logora.com/debat.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Logora Debate</title>
+  <script>
+    var logora_config = {
+      shortname: "APP_NAME",
+      remote_auth: "YOUR_JWT_TOKEN"
+    };
+  </script>
+  <script src="https://cdn.logora.com/debat.js"></script>
 </head>
 <body>
-    <div id="logora_app"></div>
+  <div id="logora_app"></div>
 </body>
 </html>
 ```
 
-### 1.2 Loading in a Mobile WebView
+### 1.2 Loading the WebView
 
-**Example in Swift (iOS)**
+#### iOS (Swift)
 
 ```swift
 import UIKit
@@ -54,27 +81,35 @@ import WebKit
 
 class DebateViewController: UIViewController {
     var webView: WKWebView!
-    
+
     override func loadView() {
-        webView = WKWebView()
-        webView.configuration.preferences.javaScriptEnabled = true
+        let config = WKWebViewConfiguration()
+        config.preferences.javaScriptEnabled = true
+        // Persist cookies and storage between app launches
+        config.websiteDataStore = WKWebsiteDataStore.default()
+
+        webView = WKWebView(frame: .zero, configuration: config)
         view = webView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        let url = URL(string: "https://yoursite.com/debate-space")!
+        let url = URL(string: "https://yoursite.com/debate-space?token=JWT")!
         webView.load(URLRequest(url: url))
     }
 }
 ```
 
-**Example in Kotlin (Android)**
+:::caution iOS — session persistence
+On iOS, without `WKWebsiteDataStore.default()`, the user may be logged out every time the WebView opens. Configure this parameter as in the example above.
+:::
+
+#### Android (Kotlin)
 
 ```kotlin
 import android.os.Bundle
-import android.webkit.WebSettings
 import android.webkit.WebView
+import android.webkit.CookieManager
 import androidx.appcompat.app.AppCompatActivity
 
 class DebateActivity : AppCompatActivity() {
@@ -82,54 +117,133 @@ class DebateActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val webView = WebView(this)
         webView.settings.javaScriptEnabled = true
-        webView.loadUrl("https://yoursite.com/debate-space")
+        webView.settings.domStorageEnabled = true
+
+        // Persist cookies between sessions
+        CookieManager.getInstance().setAcceptCookie(true)
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
+
+        webView.loadUrl("https://yoursite.com/debate-space?token=JWT")
         setContentView(webView)
     }
 }
 ```
 
-## 2. Single Sign-On (SSO) in WebView
+#### React Native
 
-For users to be automatically authenticated on Logora without re-entering their credentials, it is necessary to inject a token into `remote_auth` within `logora_config`.
+```javascript
+import { WebView } from 'react-native-webview';
 
-**Logora's SSO integration is only compatible with JWT authentication.**
+<WebView
+  source={{ uri: 'https://yoursite.com/debate-space?token=JWT' }}
+  javaScriptEnabled={true}
+  domStorageEnabled={true}
+  sharedCookiesEnabled={true}
+/>
+```
 
-You can check the detailed guide on authentication in our [JWT documentation](../../authentication/jwt).
+## 2. SSO authentication in WebView
 
-Example configuration:
+For users to be automatically authenticated on Logora without re-entering credentials, inject a token into `remote_auth` within `logora_config`.
 
 ```javascript
 var logora_config = {
-  shortname: "APPLICATION_NAME",
-  remote_auth: "YOUR_JWT_SSO_TOKEN"
+  shortname: "APP_NAME",
+  remote_auth: "YOUR_JWT_TOKEN"
 };
 ```
 
-### User Logout
+See the full guide: [JWT Authentication](/authentication/jwt).
 
-To log out a user, simply remove the `remote_auth` value or pass an empty string:
+### Logout
+
+To log the user out, remove `remote_auth` or send an empty string:
 
 ```javascript
 var logora_config = {
-  shortname: "APPLICATION_NAME",
+  shortname: "APP_NAME",
   remote_auth: ""
 };
 ```
 
-## 3. Initial Route
+## 3. Session persistence between your app and the WebView
 
-To define the first page that will be displayed in the webview, you can pass the desired path as the `initial_path` parameter:
+If your app uses a native session manager (Piano, Auth0, internal OAuth), follow these steps:
+
+1. **Get the native session token** when opening the WebView
+2. **Regenerate a Logora JWT** from the native claims (server-side)
+3. **Pass it as `remote_auth`** as above
+
+:::danger Don't try to share native cookies
+Cookie sharing between the native app and WebView is fragile and blocked by iOS/Android in most cases. **Always** use a freshly regenerated JWT on each WebView open.
+:::
+
+## 4. Initial route
+
+To open the WebView directly on a specific debate (deep linking), pass `initial_path`:
 
 ```javascript
 var logora_config = {
-    shortname: "APPLICATION_NAME",
-    initial_path: "/debate/debate-title"
+  shortname: "APP_NAME",
+  initial_path: "/debate/debate-title"
 };
 ```
 
-The application will then open directly on this page. This provides a direct link to the debate space pages.
+## 5. Handle internal links (deep linking)
 
+Logora generates links to other debates, user profiles, etc. By default they open in the WebView, which can break your native navigation.
 
-## Conclusion
+To intercept these links and open them in your native router (Cronista pattern):
 
-With this integration, your users can interact on Logora without friction, directly from your application or WebView site while benefiting from secure and seamless authentication through JWT-based SSO.
+```javascript
+// In your WebView, listen for clicks on internal links
+window.addEventListener("logoraContentLoaded", () => {
+  document.querySelectorAll("#logoraRoot a[href]").forEach(link => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      // Forward URL to native router
+      window.ReactNativeWebView?.postMessage(link.href);
+      // or for native iOS / Android:
+      // window.webkit?.messageHandlers?.linkHandler?.postMessage(link.href);
+    });
+  });
+});
+```
+
+On the native side, listen for messages and run your custom navigation.
+
+## 6. CSS adapted to WebView
+
+To use a different CSS when displayed in WebView (e.g. hide elements redundant with your app), use the `outputType` parameter:
+
+```
+https://render.logora.fr/synthesis?short_name=APP&uid=ID&outputType=webapp-type
+```
+
+Logora then applies the *webapp-type* theme configurable in *Admin > Configuration > Appearance > Themes*.
+
+## 7. iOS specifics
+
+### Third-party cookies
+
+On iOS, some WKWebView versions disable third-party cookies by default. For the Logora session, this can cause issues if your WebView domain differs from `app.logora.fr`.
+
+**Solution**: use `https://render.logora.fr` (our domain) rather than an iframe on your domain. Logora manages its session on its own domain, no third-party cookie dependency.
+
+### Dynamic theming
+
+The Logora widget supports dark mode via:
+
+```javascript
+var logora_config = {
+  theme: "dark"  // or "light", or "auto" (follows system preferences)
+};
+```
+
+---
+
+## See also
+
+- [JWT Authentication](/authentication/jwt)
+- [Appearance and theme](/configuration/theme)
+- [SSO Troubleshooting](/faq/troubleshooting-sso)

--- a/sidebars.json
+++ b/sidebars.json
@@ -31,7 +31,26 @@
       "type": "category",
       "label": "FAQ",
 	    "collapsed": false,
-      "items": ["faq/quality", "faq/performance", "faq/data", "faq/mailing", "faq/tracking", "faq/registration", "faq/thesis", "faq/invitation", "faq/journalist", "faq/share", "faq/premium", "faq/iframes", "faq/errors"]
+      "items": [
+        "faq/quality",
+        "faq/performance",
+        "faq/data",
+        "faq/account-deletion",
+        "faq/mailing",
+        "faq/notification-emails",
+        "faq/tracking",
+        "faq/registration",
+        "faq/thesis",
+        "faq/invitation",
+        "faq/journalist",
+        "faq/share",
+        "faq/premium",
+        "faq/iframes",
+        "faq/api",
+        "faq/troubleshooting-sso",
+        "faq/architecture-security",
+        "faq/errors"
+      ]
     }
   ]
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,27 +1,383 @@
-:root{
-	--ifm-color-primary: #417ec7;
-	--ifm-color-primary-dark: #3671b8;
-	--ifm-color-primary-darker: #336bad;
-	--ifm-color-primary-darkest: #2a588f;
-	--ifm-color-primary-light: #558ccd;
-	--ifm-color-primary-lighter: #6093d0;
-	--ifm-color-primary-lightest: #7ea8d9;
+/**
+ * Logora Documentation — Custom CSS
+ * Improved design for better readability
+ * 2026-04 update
+ */
+
+/* ============================================================
+   Theme colors
+   ============================================================ */
+
+:root {
+  /* Primary — Logora blue */
+  --ifm-color-primary: #417ec7;
+  --ifm-color-primary-dark: #3671b8;
+  --ifm-color-primary-darker: #336bad;
+  --ifm-color-primary-darkest: #2a588f;
+  --ifm-color-primary-light: #558ccd;
+  --ifm-color-primary-lighter: #6093d0;
+  --ifm-color-primary-lightest: #7ea8d9;
+
+  /* Typography */
+  --ifm-font-family-base: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI",
+                          Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --ifm-font-family-monospace: ui-monospace, "SF Mono", "Cascadia Code",
+                               "Roboto Mono", Menlo, Monaco, Consolas, monospace;
+  --ifm-font-size-base: 16px;
+  --ifm-line-height-base: 1.65;
+  --ifm-heading-line-height: 1.3;
+  --ifm-heading-font-weight: 700;
+
+  /* Spacing */
+  --ifm-spacing-horizontal: 1.25rem;
+  --ifm-paragraph-margin-bottom: 1.25rem;
+
+  /* Code */
+  --ifm-code-font-size: 90%;
+  --ifm-code-padding-horizontal: 0.4em;
+  --ifm-code-padding-vertical: 0.15em;
+  --ifm-code-background: rgba(65, 126, 199, 0.08);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  /* Borders & shadows */
+  --ifm-global-radius: 8px;
+  --ifm-card-border-radius: 12px;
+  --ifm-toc-border-color: #e6e8eb;
+  --ifm-table-border-color: #e6e8eb;
 }
 
+[data-theme='dark'] {
+  --ifm-background-color: #0f1419;
+  --ifm-background-surface-color: #161b22;
+  --ifm-code-background: rgba(110, 158, 220, 0.12);
+  --ifm-toc-border-color: #2a313a;
+  --ifm-table-border-color: #2a313a;
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
+}
+
+/* ============================================================
+   Typography
+   ============================================================ */
+
+article h1 {
+  font-size: 2.25rem;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.02em;
+}
+
+article h2 {
+  font-size: 1.625rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  letter-spacing: -0.01em;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+article h3 {
+  font-size: 1.25rem;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+article h4 {
+  font-size: 1.05rem;
+  margin-top: 1.5rem;
+}
+
+article p {
+  font-size: 1rem;
+  color: var(--ifm-color-content);
+}
+
+article a {
+  text-decoration: none;
+  border-bottom: 1px dashed var(--ifm-color-primary);
+  transition: all 0.15s ease;
+}
+
+article a:hover {
+  border-bottom-style: solid;
+  background: rgba(65, 126, 199, 0.08);
+}
+
+/* ============================================================
+   Code blocks
+   ============================================================ */
+
+.theme-code-block {
+  border-radius: var(--ifm-global-radius);
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.prism-code {
+  padding: 1rem 1.25rem !important;
+}
+
+code {
+  border-radius: 4px;
+  border: 1px solid rgba(65, 126, 199, 0.15);
+}
+
+/* ============================================================
+   Tables
+   ============================================================ */
+
+article table {
+  display: table;
+  width: 100%;
+  margin: 1.5rem 0;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  border-radius: var(--ifm-global-radius);
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+article table thead {
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f7 100%);
+}
+
+[data-theme='dark'] article table thead {
+  background: linear-gradient(180deg, #1d2530 0%, #181f29 100%);
+}
+
+article table th {
+  font-weight: 600;
+  text-transform: none;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--ifm-table-border-color);
+}
+
+article table td {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--ifm-table-border-color);
+  vertical-align: top;
+}
+
+article table tr:nth-child(even) td {
+  background: rgba(65, 126, 199, 0.025);
+}
+
+[data-theme='dark'] article table tr:nth-child(even) td {
+  background: rgba(110, 158, 220, 0.04);
+}
+
+/* ============================================================
+   Admonitions (tips, warnings, notes)
+   ============================================================ */
+
+.theme-admonition {
+  border-radius: var(--ifm-global-radius);
+  border-left-width: 4px;
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.theme-admonition-tip {
+  background: rgba(75, 181, 67, 0.08);
+}
+
+.theme-admonition-warning {
+  background: rgba(255, 165, 0, 0.08);
+}
+
+.theme-admonition-info {
+  background: rgba(65, 126, 199, 0.08);
+}
+
+.theme-admonition-danger {
+  background: rgba(220, 53, 69, 0.08);
+}
+
+.theme-admonition-note {
+  background: rgba(108, 117, 125, 0.06);
+}
+
+.theme-admonition-caution {
+  background: rgba(255, 193, 7, 0.08);
+}
+
+/* ============================================================
+   Blockquotes
+   ============================================================ */
+
+article blockquote {
+  border-left: 4px solid var(--ifm-color-primary);
+  padding: 0.75rem 1.25rem;
+  background: rgba(65, 126, 199, 0.04);
+  border-radius: 0 var(--ifm-global-radius) var(--ifm-global-radius) 0;
+  margin: 1.5rem 0;
+  font-style: normal;
+}
+
+article blockquote p {
+  margin-bottom: 0;
+}
+
+/* ============================================================
+   Sidebar
+   ============================================================ */
+
+.menu {
+  font-size: 0.92rem;
+  padding: 1rem 0.75rem;
+}
+
+.menu__link {
+  border-radius: 6px;
+  padding: 0.45rem 0.75rem;
+  transition: all 0.12s ease;
+}
+
+.menu__link:hover {
+  background: rgba(65, 126, 199, 0.08);
+}
+
+.menu__link--active {
+  background: rgba(65, 126, 199, 0.12);
+  font-weight: 600;
+}
+
+.menu__list-item-collapsible:hover {
+  background: rgba(65, 126, 199, 0.04);
+  border-radius: 6px;
+}
+
+/* ============================================================
+   Breadcrumbs
+   ============================================================ */
+
+.theme-doc-breadcrumbs {
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  opacity: 0.7;
+}
+
+/* ============================================================
+   TOC (right sidebar)
+   ============================================================ */
+
+.table-of-contents {
+  font-size: 0.875rem;
+}
+
+.table-of-contents__link {
+  padding: 0.25rem 0;
+  transition: color 0.12s ease;
+}
+
+.table-of-contents__link--active {
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Pagination (next/previous)
+   ============================================================ */
+
+.pagination-nav {
+  margin-top: 3rem;
+}
+
+.pagination-nav__link {
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: var(--ifm-global-radius);
+  padding: 1rem 1.25rem;
+  transition: all 0.15s ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--ifm-color-primary);
+  background: rgba(65, 126, 199, 0.04);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(65, 126, 199, 0.1);
+}
+
+.pagination-nav__sublabel {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pagination-nav__label {
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+/* ============================================================
+   Navbar
+   ============================================================ */
+
+.navbar {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+[data-theme='dark'] .navbar {
+  background: rgba(15, 20, 25, 0.95);
+}
+
+.navbar__title {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
+
+.footer {
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f7 100%);
+  padding: 2rem 0;
+}
+
+[data-theme='dark'] .footer {
+  background: linear-gradient(180deg, #161b22 0%, #0f1419 100%);
+}
+
+.footer__copyright {
+  font-size: 0.875rem;
+  opacity: 0.7;
+}
+
+/* ============================================================
+   GitHub link in navbar (preserved from original)
+   ============================================================ */
+
 .header-github-link:hover {
-	opacity: 0.6;
+  opacity: 0.6;
+}
+
+.header-github-link::before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
+    no-repeat;
+}
+
+[data-theme='dark'] .header-github-link::before {
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
+    no-repeat;
+}
+
+/* ============================================================
+   Responsive tweaks
+   ============================================================ */
+
+@media (max-width: 996px) {
+  article h1 {
+    font-size: 1.875rem;
   }
-  
-  .header-github-link::before {
-	content: '';
-	width: 24px;
-	height: 24px;
-	display: flex;
-	background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
-	  no-repeat;
+
+  article h2 {
+    font-size: 1.375rem;
   }
-  
-  [data-theme='dark'] .header-github-link::before {
-	background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
-	  no-repeat;
-  }
+}


### PR DESCRIPTION
See improvements-2026-04/README.md for the full breakdown.

## Summary
- 5 new FAQ pages (FR + EN) addressing repeatedly asked questions from clients
- 5 updated pages including a full rewrite of /configuration/moderation (Henry flagged it as outdated)
- Global CSS refresh for better readability

## Sources of changes
Analysis of support conversations across Slack (#support-clients, #développement, #krone-logora-collab, #smf-logora-sanoma, #cronista-logora, etc.) and Gmail threads from clients (Krone, Sanoma, Spiegel, Bild, Le Télégramme, FAZ, Beymedias, Estadão, Cronista, Onet, Cutowl, Suedkurier).

## Verification
- [x] yarn build passes locally
- [ ] Reviewer to verify sidebar shows 5 new entries in FAQ section
- [ ] Reviewer to verify dark mode renders well with new custom.css
